### PR TITLE
[ADD][account_cutoff_accrual_base] Add a default journal configuration for each type of cutoff

### DIFF
--- a/account_cutoff_accrual_base/account_cutoff.py
+++ b/account_cutoff_accrual_base/account_cutoff.py
@@ -48,9 +48,14 @@ class account_cutoff(orm.Model):
             ._get_default_journal(cr, uid, context=context)
         cur_user = self.pool['res.users'].browse(cr, uid, uid, context=context)
         cutoff_type = context.get('type', False)
-        if cutoff_type in ['accrued_expense', 'accrued_revenue']:
-            journal_id = cur_user.company_id.\
-                default_accrual_journal_id.id or False
+        default_journal_id = cur_user.company_id\
+            .default_cutoff_journal_id.id or False
+        if cutoff_type == 'accrued_expense':
+            journal_id = cur_user.company_id\
+                .default_accrual_expense_journal_id.id or default_journal_id
+        elif cutoff_type == 'accrued_revenue':
+            journal_id = cur_user.company_id\
+                .default_accrual_revenue_journal_id.id or default_journal_id
         return journal_id
 
 

--- a/account_cutoff_accrual_base/account_cutoff.py
+++ b/account_cutoff_accrual_base/account_cutoff.py
@@ -43,6 +43,16 @@ class account_cutoff(orm.Model):
             account_id = company.default_accrued_revenue_account_id.id or False
         return account_id
 
+    def _get_default_journal(self, cr, uid, context=None):
+        journal_id = super(account_cutoff, self)\
+            ._get_default_journal(cr, uid, context=context)
+        cur_user = self.pool['res.users'].browse(cr, uid, uid, context=context)
+        cutoff_type = context.get('type', False)
+        if cutoff_type in ['accrued_expense', 'accrued_revenue']:
+            journal_id = cur_user.company_id.\
+                default_accrual_journal_id.id or False
+        return journal_id
+
 
 class account_cutoff_line(orm.Model):
     _inherit = 'account.cutoff.line'

--- a/account_cutoff_accrual_base/account_cutoff.py
+++ b/account_cutoff_accrual_base/account_cutoff.py
@@ -51,11 +51,13 @@ class account_cutoff(orm.Model):
         default_journal_id = cur_user.company_id\
             .default_cutoff_journal_id.id or False
         if cutoff_type == 'accrued_expense':
-            journal_id = cur_user.company_id\
-                .default_accrual_expense_journal_id.id or default_journal_id
+            journal_id =\
+                cur_user.company_id.default_accrual_expense_journal_id.id or\
+                default_journal_id
         elif cutoff_type == 'accrued_revenue':
-            journal_id = cur_user.company_id\
-                .default_accrual_revenue_journal_id.id or default_journal_id
+            journal_id = \
+                cur_user.company_id.default_accrual_revenue_journal_id.id or\
+                default_journal_id
         return journal_id
 
 

--- a/account_cutoff_accrual_base/company.py
+++ b/account_cutoff_accrual_base/company.py
@@ -34,6 +34,8 @@ class res_company(orm.Model):
         'default_accrued_expense_account_id': fields.many2one(
             'account.account', 'Default Account for Accrued Expenses',
             domain=[('type', '<>', 'view'), ('type', '<>', 'closed')]),
-        'default_accrual_journal_id': fields.many2one(
-            'account.journal', 'Default Accrual Cut-off Journal'),
+        'default_accrual_revenue_journal_id': fields.many2one(
+            'account.journal', 'Default Journal for Accrued Revenues'),
+        'default_accrual_expense_journal_id': fields.many2one(
+            'account.journal', 'Default Journal for Accrued Expenses'),
     }

--- a/account_cutoff_accrual_base/company.py
+++ b/account_cutoff_accrual_base/company.py
@@ -34,4 +34,6 @@ class res_company(orm.Model):
         'default_accrued_expense_account_id': fields.many2one(
             'account.account', 'Default Account for Accrued Expenses',
             domain=[('type', '<>', 'view'), ('type', '<>', 'closed')]),
+        'default_accrual_journal_id': fields.many2one(
+            'account.journal', 'Default Accrual Cut-off Journal'),
     }

--- a/account_cutoff_accrual_base/company_view.xml
+++ b/account_cutoff_accrual_base/company_view.xml
@@ -14,12 +14,14 @@
     <field name="model">res.company</field>
     <field name="inherit_id" ref="account_cutoff_base.view_company_form" />
     <field name="arch" type="xml">
-        <field name="default_cutoff_journal_id" position="after">
+        <xpath expr="//group[@name='cutoff_journal']" positon="inside">
             <field name="default_accrual_revenue_journal_id" />
             <field name="default_accrual_expense_journal_id" />
+        </xpath>
+        <xpath expr="//group[@name='cutoff_account']" positon="after">
             <field name="default_accrued_revenue_account_id" />
             <field name="default_accrued_expense_account_id" />
-        </field>
+        </xpath>
     </field>
 </record>
 

--- a/account_cutoff_accrual_base/company_view.xml
+++ b/account_cutoff_accrual_base/company_view.xml
@@ -15,7 +15,8 @@
     <field name="inherit_id" ref="account_cutoff_base.view_company_form" />
     <field name="arch" type="xml">
         <field name="default_cutoff_journal_id" position="after">
-            <field name="default_accrual_journal_id" />
+            <field name="default_accrual_revenue_journal_id" />
+            <field name="default_accrual_expense_journal_id" />
             <field name="default_accrued_revenue_account_id" />
             <field name="default_accrued_expense_account_id" />
         </field>

--- a/account_cutoff_accrual_base/company_view.xml
+++ b/account_cutoff_accrual_base/company_view.xml
@@ -15,6 +15,7 @@
     <field name="inherit_id" ref="account_cutoff_base.view_company_form" />
     <field name="arch" type="xml">
         <field name="default_cutoff_journal_id" position="after">
+            <field name="default_accrual_journal_id" />
             <field name="default_accrued_revenue_account_id" />
             <field name="default_accrued_expense_account_id" />
         </field>

--- a/account_cutoff_base/account_cutoff.py
+++ b/account_cutoff_base/account_cutoff.py
@@ -152,7 +152,8 @@ class account_cutoff(orm.Model):
         'company_id': lambda self, cr, uid, context:
         self.pool['res.users'].browse(
             cr, uid, uid, context=context).company_id.id,
-        'cutoff_journal_id': _get_default_journal,
+        'cutoff_journal_id': lambda self, cr, uid, context: self.
+            _get_default_journal(cr, uid, context=context),
         'move_label': _default_move_label,
         'type': _default_type,
         'cutoff_account_id': _default_cutoff_account_id,

--- a/account_cutoff_base/company_view.xml
+++ b/account_cutoff_base/company_view.xml
@@ -15,8 +15,10 @@
     <field name="inherit_id" ref="base.view_company_form" />
     <field name="arch" type="xml">
         <group name="account_grp" position="after">
-            <group name="cutoff" string="Cut-offs">
+            <group name="cutoff_journal" string="Cut-offs Journals">
                 <field name="default_cutoff_journal_id" />
+            </group>
+            <group name="cutoff_account" string="Cut-offs Accounts">
             </group>
         </group>
     </field>

--- a/account_cutoff_prepaid/account_cutoff.py
+++ b/account_cutoff_prepaid/account_cutoff.py
@@ -138,7 +138,7 @@ class account_cutoff(orm.Model):
             ('end_date', '>', cutoff_date_str),
             ('date', '<=', cutoff_date_str)
         ], context=context)
-        # Create mapping dict                
+        # Create mapping dict
         mapping = mapping_obj._get_mapping_dict(
             cr, uid, cur_cutoff['company_id'][0], cur_cutoff['type'],
             context=context)

--- a/account_cutoff_prepaid/account_cutoff.py
+++ b/account_cutoff_prepaid/account_cutoff.py
@@ -62,7 +62,7 @@ class account_cutoff(orm.Model):
         'unique(cutoff_date, company_id, type)',
         'A cut-off of the same type already exists with this cut-off date !'
     )]
-    
+
     def _prepare_prepaid_lines(
             self, cr, uid, ids, aml, cur_cutoff, mapping, context=None):
         start_date = datetime.strptime(aml['start_date'], '%Y-%m-%d')

--- a/account_cutoff_prepaid/account_cutoff.py
+++ b/account_cutoff_prepaid/account_cutoff.py
@@ -62,7 +62,7 @@ class account_cutoff(orm.Model):
         'unique(cutoff_date, company_id, type)',
         'A cut-off of the same type already exists with this cut-off date !'
     )]
-
+    
     def _prepare_prepaid_lines(
             self, cr, uid, ids, aml, cur_cutoff, mapping, context=None):
         start_date = datetime.strptime(aml['start_date'], '%Y-%m-%d')
@@ -170,6 +170,21 @@ class account_cutoff(orm.Model):
         elif type == 'prepaid_expense':
             account_id = company.default_prepaid_expense_account_id.id or False
         return account_id
+
+    def _get_default_journal(self, cr, uid, context=None):
+        journal_id = super(account_cutoff, self)\
+            ._get_default_journal(cr, uid, context=context)
+        cur_user = self.pool['res.users'].browse(cr, uid, uid, context=context)
+        cutoff_type = context.get('type', False)
+        default_journal_id = cur_user.company_id\
+            .default_cutoff_journal_id.id or False
+        if cutoff_type == 'prepaid_expense':
+            journal_id = cur_user.company_id\
+                .default_prepaid_expense_journal_id.id or default_journal_id
+        elif cutoff_type == 'prepaid_revenue':
+            journal_id = cur_user.company_id\
+                .default_prepaid_revenue_journal_id.id or default_journal_id
+        return journal_id
 
 
 class account_cutoff_line(orm.Model):

--- a/account_cutoff_prepaid/account_cutoff.py
+++ b/account_cutoff_prepaid/account_cutoff.py
@@ -138,7 +138,7 @@ class account_cutoff(orm.Model):
             ('end_date', '>', cutoff_date_str),
             ('date', '<=', cutoff_date_str)
         ], context=context)
-        # Create mapping dict
+        # Create mapping dict                
         mapping = mapping_obj._get_mapping_dict(
             cr, uid, cur_cutoff['company_id'][0], cur_cutoff['type'],
             context=context)
@@ -179,11 +179,13 @@ class account_cutoff(orm.Model):
         default_journal_id = cur_user.company_id\
             .default_cutoff_journal_id.id or False
         if cutoff_type == 'prepaid_expense':
-            journal_id = cur_user.company_id\
-                .default_prepaid_expense_journal_id.id or default_journal_id
+            journal_id =\
+                cur_user.company_id.default_prepaid_expense_journal_id.id or\
+                default_journal_id
         elif cutoff_type == 'prepaid_revenue':
-            journal_id = cur_user.company_id\
-                .default_prepaid_revenue_journal_id.id or default_journal_id
+            journal_id =\
+                cur_user.company_id.default_prepaid_revenue_journal_id.id or\
+                default_journal_id
         return journal_id
 
 

--- a/account_cutoff_prepaid/company.py
+++ b/account_cutoff_prepaid/company.py
@@ -34,4 +34,8 @@ class res_company(orm.Model):
         'default_prepaid_expense_account_id': fields.many2one(
             'account.account', 'Default Account for Prepaid Expense',
             domain=[('type', '<>', 'view'), ('type', '<>', 'closed')]),
+        'default_prepaid_revenue_journal_id': fields.many2one(
+            'account.journal', 'Default Journal for Prepaid Revenues'),
+        'default_prepaid_expense_journal_id': fields.many2one(
+            'account.journal', 'Default Journal for Prepaid Expenses'),
     }

--- a/account_cutoff_prepaid/company_view.xml
+++ b/account_cutoff_prepaid/company_view.xml
@@ -15,12 +15,14 @@
     <field name="model">res.company</field>
     <field name="inherit_id" ref="account_cutoff_base.view_company_form" />
     <field name="arch" type="xml">
-        <field name="default_cutoff_journal_id" position="after">
+        <xpath expr="//group[@name='cutoff_journal']" positon="inside">
             <field name="default_prepaid_revenue_journal_id" />
             <field name="default_prepaid_expense_journal_id" />
+        </xpath>
+        <xpath expr="//group[@name='cutoff_account']" positon="inside">
             <field name="default_prepaid_revenue_account_id" />
             <field name="default_prepaid_expense_account_id" />
-        </field>
+        </xpath>
     </field>
 </record>
 

--- a/account_cutoff_prepaid/company_view.xml
+++ b/account_cutoff_prepaid/company_view.xml
@@ -16,6 +16,8 @@
     <field name="inherit_id" ref="account_cutoff_base.view_company_form" />
     <field name="arch" type="xml">
         <field name="default_cutoff_journal_id" position="after">
+            <field name="default_prepaid_revenue_journal_id" />
+            <field name="default_prepaid_expense_journal_id" />
             <field name="default_prepaid_revenue_account_id" />
             <field name="default_prepaid_expense_account_id" />
         </field>


### PR DESCRIPTION
Add a default journal configuration for each type of cutoff.

The default cutoff journal is kept for backward compatibility and as a fallback if no default journal is defined for a specific type of cutoff.
