### PR TITLE
[IMP] account_cutoff_base: cutoff moves always need to be reversed

### DIFF
--- a/account_cutoff_base/__openerp__.py
+++ b/account_cutoff_base/__openerp__.py
@@ -42,7 +42,10 @@ for any help or question about this module.
     """,
     'author': "Akretion,Odoo Community Association (OCA)",
     'website': 'http://www.akretion.com',
-    'depends': ['account_accountant'],
+    'depends': [
+        'account_accountant',
+        'account_reversal',
+    ],
     'data': [
         'company_view.xml',
         'account_cutoff_view.xml',

--- a/account_cutoff_base/account_cutoff.py
+++ b/account_cutoff_base/account_cutoff.py
@@ -230,6 +230,7 @@ class account_cutoff(orm.Model):
             'date': cur_cutoff.cutoff_date,
             'period_id': period_id,
             'ref': move_label,
+            'to_be_reversed': True,
             'line_id': movelines_to_create,
         }
         return res


### PR DESCRIPTION
So we set the to_be_reversed flag so it is easy to find the moves
that have to be reversed and not forget them.
