### PR TITLE
FIX error in view account_invoice_view

### DIFF
--- a/account_cutoff_prepaid/README.rst
+++ b/account_cutoff_prepaid/README.rst
@@ -25,6 +25,7 @@ Contributors
 
 * Alexis de Lattre <alexis@via.ecp.fr>
 * Stéphane Bidoul <stephane.bidoul@acsone.eu>
+* Daniel Rodríguez Lijo <drl.9319@gmail.com>
 
 Maintainer
 ----------

--- a/account_cutoff_prepaid/account_invoice_view.xml
+++ b/account_cutoff_prepaid/account_invoice_view.xml
@@ -15,7 +15,7 @@
     <field name="model">account.invoice</field>
     <field name="inherit_id" ref="account.invoice_form" />
     <field name="arch" type="xml">
-        <xpath expr="//field[@name='invoice_line']/tree/field[@name='account_analytic_id']" position="after">
+        <xpath expr="//field[@name='invoice_line']/tree/field[@name='quantity']" position="before">
             <field name="start_date" />
             <field name="end_date" />
         </xpath>
@@ -33,7 +33,7 @@
     <field name="model">account.invoice</field>
     <field name="inherit_id" ref="account.invoice_supplier_form" />
     <field name="arch" type="xml">
-        <xpath expr="//field[@name='invoice_line']/tree/field[@name='account_analytic_id']" position="after">
+        <xpath expr="//field[@name='invoice_line']/tree/field[@name='quantity']" position="before">
             <field name="start_date" />
             <field name="end_date" />
         </xpath>


### PR DESCRIPTION
I found a error when I installes this module becouse in my system have check four settings in Configuration -> Accounting: 
1. Analytic accounting for sales
2. Use multiple analytic accounts on sales
3. Analytic accounting for purchases
4. Use multiple analytic accounts on orders

when this four settings are check, Odoo will install sale_analytic_plans and purchase_analytic_plans addons, this addons delete account_analytic_id field from invoice form. For this when this addon needs insert two fields after this have a problem, for fix this problem I think the best solutions is insert this fields before quantity field, the place of this two field it is the same and quantity field is never delete.
