### PR TITLE
[8.0] account_cutoff_* : allow use by Accountant

### DIFF
--- a/account_cutoff_base/security/ir.model.access.csv
+++ b/account_cutoff_base/security/ir.model.access.csv
@@ -1,9 +1,6 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_account_cutoff_mapping,Full access on account.cutoff.mapping,model_account_cutoff_mapping,account.group_account_manager,1,1,1,1
 access_account_cutoff_mapping_user,Read access on account.cutoff.mapping,model_account_cutoff_mapping,base.group_user,1,0,0,0
-access_account_cutoff,Full access on account.cutoff,model_account_cutoff,account.group_account_manager,1,1,1,1
-access_account_cutoff_read,Read access on account.cutoff,model_account_cutoff,account.group_account_user,1,0,0,0
-access_account_cutoff_line,Full access on account.cutoff.line,model_account_cutoff_line,account.group_account_manager,1,1,1,1
-access_account_cutoff_line_read,Read access on account.cutoff.line,model_account_cutoff_line,account.group_account_user,1,0,0,0
-access_account_cutoff_tax_line,Full access on account.cutoff.tax.line,model_account_cutoff_tax_line,account.group_account_manager,1,1,1,1
-access_account_cutoff_tax_line_read,Read access on account.cutoff.tax.line,model_account_cutoff_tax_line,account.group_account_user,1,0,0,0
+access_account_cutoff,Full access on account.cutoff to accountant,model_account_cutoff,account.group_account_user,1,1,1,1
+access_account_cutoff_line,Full access on account.cutoff.line to accountant,model_account_cutoff_line,account.group_account_user,1,1,1,1
+access_account_cutoff_tax_line,Full access on account.cutoff.tax.line to accountant,model_account_cutoff_tax_line,account.group_account_user,1,1,1,1


### PR DESCRIPTION
allow use by Accountant, not just by Financial Manager.

The Cutoff objects are not "configuration" items, but regular accounting use, so it should be accessible by default by the Accountant.

If you agree on this, I'll up-port this PR to newer versions.