### PR TITLE
[FIX] runbot build on 11.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
   - git clone https://github.com/OCA/account-financial-tools ${HOME}/account-financial-tools -b ${VERSION}
   - git clone https://github.com/OCA/webkit-tools ${HOME}/webkit-tools -b ${VERSION}
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
+  - pip install phonenumbers
   - travis_install_nightly
 
 script:


### PR DESCRIPTION
the runbot build is 'orange' because of a warning issued
when an undocumented semi-dependency is not present. Check
that installing it cures the build