### PR TITLE
[10.0] Allow to configure different account for refunds (credit notes)

### DIFF
--- a/account_cutoff_accrual_base/i18n/fr.po
+++ b/account_cutoff_accrual_base/i18n/fr.po
@@ -69,13 +69,25 @@ msgstr "Sociétés"
 #: model:ir.model.fields,field_description:account_cutoff_accrual_base.field_account_config_settings_default_accrued_expense_account_id
 #: model:ir.model.fields,field_description:account_cutoff_accrual_base.field_res_company_default_accrued_expense_account_id
 msgid "Default Account for Accrued Expenses"
-msgstr "Compte par défaut pour factures non parvenues"
+msgstr "Compte par défaut pour les factures non parvenues"
+
+#. module: account_cutoff_accrual_base
+#: model:ir.model.fields,field_description:account_cutoff_accrual_base.field_account_config_settings_default_accrued_expense_return_account_id
+#: model:ir.model.fields,field_description:account_cutoff_accrual_base.field_res_company_default_accrued_expense_return_account_id
+msgid "Default Account for Accrued Expenses Returns"
+msgstr "Compte par défaut pour les notes de crédit à recevoir"
 
 #. module: account_cutoff_accrual_base
 #: model:ir.model.fields,field_description:account_cutoff_accrual_base.field_account_config_settings_default_accrued_revenue_account_id
 #: model:ir.model.fields,field_description:account_cutoff_accrual_base.field_res_company_default_accrued_revenue_account_id
 msgid "Default Account for Accrued Revenues"
-msgstr "Compte par défaut pour factures à établir"
+msgstr "Compte par défaut pour les factures à établir"
+
+#. module: account_cutoff_accrual_base
+#: model:ir.model.fields,field_description:account_cutoff_accrual_base.field_account_config_settings_default_accrued_revenue_return_account_id
+#: model:ir.model.fields,field_description:account_cutoff_accrual_base.field_res_company_default_accrued_revenue_return_account_id
+msgid "Default Account for Accrued Revenues Returns"
+msgstr "Compte par défaut pour les notes de crédit à établir"
 
 #. module: account_cutoff_accrual_base
 #: model:ir.model.fields,field_description:account_cutoff_accrual_base.field_account_config_settings_default_accrual_expense_journal_id

--- a/account_cutoff_accrual_base/models/account_config_settings.py
+++ b/account_cutoff_accrual_base/models/account_config_settings.py
@@ -11,8 +11,12 @@ class AccountConfigSettings(models.TransientModel):
 
     default_accrued_revenue_account_id = fields.Many2one(
         related='company_id.default_accrued_revenue_account_id')
+    default_accrued_revenue_return_account_id = fields.Many2one(
+        related='company_id.default_accrued_revenue_return_account_id')
     default_accrued_expense_account_id = fields.Many2one(
         related='company_id.default_accrued_expense_account_id')
+    default_accrued_expense_return_account_id = fields.Many2one(
+        related='company_id.default_accrued_expense_return_account_id')
     default_accrual_revenue_journal_id = fields.Many2one(
         related='company_id.default_accrual_revenue_journal_id')
     default_accrual_expense_journal_id = fields.Many2one(

--- a/account_cutoff_accrual_base/models/company.py
+++ b/account_cutoff_accrual_base/models/company.py
@@ -14,9 +14,19 @@ class ResCompany(models.Model):
         string='Default Account for Accrued Revenues',
         domain=[('deprecated', '=', False)])
 
+    default_accrued_revenue_return_account_id = fields.Many2one(
+        comodel_name='account.account',
+        string='Default Account for Accrued Revenues Returns',
+        domain=[('deprecated', '=', False)])
+
     default_accrued_expense_account_id = fields.Many2one(
         comodel_name='account.account',
         string='Default Account for Accrued Expenses',
+        domain=[('deprecated', '=', False)])
+
+    default_accrued_expense_return_account_id = fields.Many2one(
+        comodel_name='account.account',
+        string='Default Account for Accrued Expenses Returns',
         domain=[('deprecated', '=', False)])
 
     default_accrual_revenue_journal_id = fields.Many2one(

--- a/account_cutoff_accrual_base/views/account_config_settings.xml
+++ b/account_cutoff_accrual_base/views/account_config_settings.xml
@@ -16,7 +16,9 @@
             <field name="default_accrual_revenue_journal_id" />
             <field name="default_accrual_expense_journal_id" />
             <field name="default_accrued_revenue_account_id" />
+            <field name="default_accrued_revenue_return_account_id" />
             <field name="default_accrued_expense_account_id" />
+            <field name="default_accrued_expense_return_account_id" />
         </field>
     </field>
 </record>


### PR DESCRIPTION
Allow to book cut-off of invoice to receive and credit note (refund) to receive on different accounts. Same for invoice / refund to make.

This PR is used in invoice accrual PR and accrual picking PR