### PR TITLE
[10.0][FIX] account-multicurrency-revaluation:  add hours to revaluation date as it is required to find out the correct rate

### DIFF
--- a/account_multicurrency_revaluation/wizard/wizard_currency_revaluation.py
+++ b/account_multicurrency_revaluation/wizard/wizard_currency_revaluation.py
@@ -65,10 +65,10 @@ class WizardCurrencyRevaluation(models.TransientModel):
 
         # Compute unrealized gain loss
         ctx_rate = context.copy()
-        ctx_rate['date'] = form.revaluation_date
+        ctx_rate['date'] = '%s %s' % (form.revaluation_date, '23:59:59')
         cp_currency = form.journal_id.company_id.currency_id
 
-        currency = currency_obj.browse(currency_id)
+        currency = currency_obj.with_context(ctx_rate).browse(currency_id)
 
         foreign_balance = adjusted_balance = balances.get(
             'foreign_balance', 0.0)
@@ -76,7 +76,7 @@ class WizardCurrencyRevaluation(models.TransientModel):
         unrealized_gain_loss = 0.0
         if foreign_balance:
             ctx_rate['revaluation'] = True
-            adjusted_balance = currency.with_context(ctx_rate).compute(
+            adjusted_balance = currency.compute(
                 foreign_balance, cp_currency
             )
             unrealized_gain_loss = adjusted_balance - balance


### PR DESCRIPTION
The revaluation wizard requests a data in input but currency rates are searched based on a DateTime.

If you try to revaluate on July 31, you will get the rate of July 30.
This because of this query: https://github.com/odoo/odoo/blob/10.0/odoo/addons/base/res/res_currency.py#L43

The name of the currency rate is the date with hours in string

For example '2018/07/31'  is not higher than '2018/07/31 10:00:00'

This PR fixes the problem by adding '23:59:59' behind the wizard date.