### PR TITLE
[IMP][10][account_multicurrency_revaluation] add rate_type

### DIFF
--- a/account_multicurrency_revaluation/__manifest__.py
+++ b/account_multicurrency_revaluation/__manifest__.py
@@ -11,6 +11,7 @@
  "depends": [
      "account_reversal",
      "account_financial_report_qweb",
+     "currency_monthly_rate",
  ],
  "demo": [
      "demo/account_demo.xml",

--- a/account_multicurrency_revaluation/model/res_company.py
+++ b/account_multicurrency_revaluation/model/res_company.py
@@ -57,3 +57,9 @@ class ResCompany(models.Model):
              "as \"To Be Reversed\".",
         default=True,
     )
+    rate_type = fields.Selection(
+        string="Rate type", selection=[
+            ('average', 'Average'),
+            ('daily', 'Daily'),
+        ],
+        default='average')

--- a/account_multicurrency_revaluation/model/res_config.py
+++ b/account_multicurrency_revaluation/model/res_config.py
@@ -67,3 +67,10 @@ class AccountConfigSettings(models.TransientModel):
              "as \"To Be Reversed\".",
         default=True,
     )
+    rate_type = fields.Selection(
+        related='company_id.rate_type',
+        string='Rate type *',
+        help="Revaluations entries will be created "
+             "as \"To Be Reversed\".",
+        default='average',
+    )

--- a/account_multicurrency_revaluation/model/res_config.py
+++ b/account_multicurrency_revaluation/model/res_config.py
@@ -72,5 +72,4 @@ class AccountConfigSettings(models.TransientModel):
         string='Rate type *',
         help="Revaluations entries will be created "
              "as \"To Be Reversed\".",
-        default='average',
     )

--- a/account_multicurrency_revaluation/views/res_config_view.xml
+++ b/account_multicurrency_revaluation/views/res_config_view.xml
@@ -39,6 +39,7 @@
                     </table>
                     <group>
                         <field name="default_currency_reval_journal_id"/>
+                        <field name="rate_type"/>
                     </group>
                 </group>
             </xpath>

--- a/account_multicurrency_revaluation/wizard/wizard_currency_revaluation.py
+++ b/account_multicurrency_revaluation/wizard/wizard_currency_revaluation.py
@@ -59,7 +59,7 @@ class WizardCurrencyRevaluation(models.TransientModel):
             ('average', 'Average'),
             ('daily', 'Daily'),
         ],
-        default=_get_default_rate_type,
+        default=lambda self: self._get_default_rate_type(),
     )
 
     @api.model

--- a/account_multicurrency_revaluation/wizard/wizard_currency_revaluation.py
+++ b/account_multicurrency_revaluation/wizard/wizard_currency_revaluation.py
@@ -24,6 +24,13 @@ class WizardCurrencyRevaluation(models.TransientModel):
         """
         return self.env.user.company_id.default_currency_reval_journal_id
 
+    @api.model
+    def _get_default_rate_type(self):
+        """
+        Get default rate type if one is defined in company settings
+        """
+        return self.env.user.company_id.rate_type
+
     revaluation_date = fields.Date(
         string='Revaluation Date',
         required=True,
@@ -45,6 +52,14 @@ class WizardCurrencyRevaluation(models.TransientModel):
         required=True,
         default="%(currency)s %(account)s "
                 "%(rate)s currency revaluation"
+    )
+    rate_type_wizard = fields.Selection(
+        string='Rate type',
+        selection=[
+            ('average', 'Average'),
+            ('daily', 'Daily'),
+        ],
+        default=_get_default_rate_type,
     )
 
     @api.model
@@ -281,7 +296,7 @@ class WizardCurrencyRevaluation(models.TransientModel):
         # Get balance sums
         account_sums = account_ids.compute_revaluations(self.revaluation_date)
 
-        monthly_rate = (company.rate_type == 'average')
+        monthly_rate = (self.rate_type_wizard == 'average')
 
         for account_id, account_tree in account_sums.iteritems():
             for currency_id, currency_tree in account_tree.iteritems():

--- a/account_multicurrency_revaluation/wizard/wizard_currency_revaluation.py
+++ b/account_multicurrency_revaluation/wizard/wizard_currency_revaluation.py
@@ -100,8 +100,11 @@ class WizardCurrencyRevaluation(models.TransientModel):
             if balance:
                 if currency_id != cp_currency.id:
                     unrealized_gain_loss = 0.0 - balance
+        rate = currency.rate
+        if ctx_rate.get('monthly_rate'):
+            rate = currency.monthly_rate
         return {'unrealized_gain_loss': unrealized_gain_loss,
-                'currency_rate': currency.rate,
+                'currency_rate': rate,
                 'revaluated_balance': adjusted_balance}
 
     @api.model

--- a/account_multicurrency_revaluation/wizard/wizard_currency_revaluation_view.xml
+++ b/account_multicurrency_revaluation/wizard/wizard_currency_revaluation_view.xml
@@ -14,6 +14,7 @@
                     <group>
                         <field name="revaluation_date" />
                         <field name="journal_id"/>
+                        <field name="rate_type_wizard" />
                     </group>
                     <group colspan="4">
                         <field name="label"/>

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,3 +1,4 @@
 account-financial-reporting
 account-financial-tools
 account-invoicing
+currency

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,4 +1,4 @@
 account-financial-reporting
 account-financial-tools
 account-invoicing
-currency https://github.com/OCA/currency/pull/39
+currency

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,4 +1,4 @@
 account-financial-reporting
 account-financial-tools
 account-invoicing
-currency
+currency https://github.com/OCA/currency/pull/39


### PR DESCRIPTION
To add the possibility to have the **Average** or **Daily** **rate type** still selected on the company

**Accounting config** 
![image](https://user-images.githubusercontent.com/32262135/50975583-3e35dc80-14ee-11e9-8e27-97cf7576b621.png)

-----

**Currency revaluation wizard**
![image](https://user-images.githubusercontent.com/32262135/51025051-5e67a900-158b-11e9-93e0-cb132863e7d5.png)

-------


**Related to :** 

* [https://github.com/OCA/currency/pull/39](https://github.com/OCA/currency/pull/39)

* [https://github.com/OCA/account-closing/commit/e7e04f3f85ec472303b975c553ad4bae4958bacd](https://github.com/OCA/account-closing/commit/e7e04f3f85ec472303b975c553ad4bae4958bacd)
