### PR TITLE
[REF] account_multicurrency_revaluation: Set the revaluation date on …

### DIFF
--- a/account_multicurrency_revaluation/tests/test_currency_revaluation.py
+++ b/account_multicurrency_revaluation/tests/test_currency_revaluation.py
@@ -161,7 +161,7 @@ class TestCurrencyRevaluation(SavepointCase):
             'revaluation_date': '%s-03-15' % fields.Date.from_string(
                 fields.Date.today()).strftime('%Y'),
             'journal_id': self.reval_journal.id,
-            'label': '[%(account)s] wiz_test',
+            'label': '[%(account)s %(rate)s] wiz_test',
         }
         wiz = wizard.create(data)
         result = wiz.revaluate_currency()
@@ -176,6 +176,8 @@ class TestCurrencyRevaluation(SavepointCase):
         self.assertEqual(len(reval_move_lines), 8)
 
         for reval_line in reval_move_lines:
+            self.assertEqual(
+                reval_line.name.split(' ')[1].split(']')[0], '2.5')
             if reval_line.account_id.name == 'Account Liquidity USD':
                 self.assertFalse(reval_line.partner_id)
                 self.assertEqual(reval_line.credit, 0.0)

--- a/account_multicurrency_revaluation/wizard/wizard_currency_revaluation.py
+++ b/account_multicurrency_revaluation/wizard/wizard_currency_revaluation.py
@@ -273,6 +273,8 @@ class WizardCurrencyRevaluation(models.TransientModel):
 
         @return: dict to open an Entries view filtered on generated move lines
         """
+        ctx_rate = self._context.copy()
+        ctx_rate['date'] = self.revaluation_date
 
         account_obj = self.env['account.account']
 
@@ -308,9 +310,10 @@ class WizardCurrencyRevaluation(models.TransientModel):
                     if not sums['balance']:
                         continue
                     # Update sums with compute amount currency balance
-                    diff_balances = self._compute_unrealized_currency_gl(
-                        currency_id,
-                        sums, self)
+                    diff_balances = self.with_context(
+                        ctx_rate)._compute_unrealized_currency_gl(
+                            currency_id,
+                            sums, self)
                     account_sums[account_id][currency_id][partner_id].\
                         update(diff_balances)
 


### PR DESCRIPTION
…the context when calling the revaluate_currency method on the wizard view, to correctly use the rate of the input date, because without this change, the rate used for the creation of the move and lines would be of the day of creation and not of the required date.