### PR TITLE
[10][IMP]account_multicurrency_revaluation report currency unrealized

### DIFF
--- a/account_multicurrency_revaluation/__manifest__.py
+++ b/account_multicurrency_revaluation/__manifest__.py
@@ -10,6 +10,7 @@
  "license": 'AGPL-3',
  "depends": [
      "account_reversal",
+     "account_financial_report_qweb",
  ],
  "demo": [
      "demo/account_demo.xml",

--- a/account_multicurrency_revaluation/report/currency_unrealized_report.py
+++ b/account_multicurrency_revaluation/report/currency_unrealized_report.py
@@ -31,7 +31,9 @@ class ShellAccount(object):
         ndigits = dp.get_precision('Account')(self.cursor)[1]
         val_formated = val
         if isinstance(val, float):
-            val_formated = "%.2f" % tools.float_round(val, ndigits)
+            val_formated = tools.float_repr(
+                tools.float_round(val, ndigits), ndigits
+            )
         return val_formated
 
     def get_lines(self):

--- a/account_multicurrency_revaluation/report/currency_unrealized_report.py
+++ b/account_multicurrency_revaluation/report/currency_unrealized_report.py
@@ -3,8 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 from odoo import api, models
-
-FLOAT_DIGIT = 2
+from odoo.addons import decimal_precision as dp
 
 
 class ShellAccount(object):
@@ -31,7 +30,8 @@ class ShellAccount(object):
     def __contains__(self, key):
         return hasattr(self, key)
 
-    def _format_float(self, val, ndigits=FLOAT_DIGIT):
+    def _format_float(self, val):
+        ndigits = dp.get_precision('Account')(self.cursor)[1]
         val_formated = val
         if isinstance(val, float):
             val_formated = "%.2f" % round(val, ndigits=ndigits)
@@ -91,7 +91,7 @@ class ShellAccount(object):
                 setattr(self, key + '_total_check', False)
 
     def format_ordered_lines(self):
-        """ To render only float with 2 digits
+        """ To render only float with right digits for account
         """
         for line in self.ordered_lines:
             for key, val in line.iteritems():

--- a/account_multicurrency_revaluation/report/report.xml
+++ b/account_multicurrency_revaluation/report/report.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <report name="account_multicurrency_revaluation.curr_unrealized"
-            string="Unrealized currency report"
+            string="Currency revaluation report"
             id="action_report_currency_unrealized"
             model="account.account"
             file="account_multicurrency_revaluation.curr_unrealized"

--- a/account_multicurrency_revaluation/report/unrealized_currency_gain_loss.xml
+++ b/account_multicurrency_revaluation/report/unrealized_currency_gain_loss.xml
@@ -39,38 +39,50 @@
                                         <div class="act_as_cell first_column amount" style="width: 100px;">Gain(+)/Loss(-) YTD</div>
                                     </div>
                                     <t t-foreach="sh_acc.ordered_lines" t-as="line">
-                                        <div class="act_as_row lines">
-                                            <div class="act_as_cell">
-                                                <span t-esc="line.get('name') or '--'"/>
+                                        <t t-if="account.internal_type in ['payable', 'receivable']">
+                                            <div class="act_as_row lines">
+                                                <div class="act_as_cell">
+                                                    <span t-esc="line.get('name') or '--'"/>
+                                                </div>
+                                                <div class="act_as_cell amount" style="width: 100px;">
+                                                    <span t-esc="line.get('gl_foreign_balance') or 0.0"/>
+                                                </div>
+                                                <div class="act_as_cell" style="width: 50px;">
+                                                    <span t-esc="line.get('curr_name') or '--'"/>
+                                                </div>
+                                                <div class="act_as_cell amount" style="width: 80px;">
+                                                    <span t-esc="line.get('gl_currency_rate') or 0.0"/>
+                                                </div>
+                                                <div class="act_as_cell amount" style="width: 150px;">
+                                                    <span t-esc="line.get('gl_revaluated_balance') or 0.0"/>
+                                                </div>
+                                                <div class="act_as_cell amount" style="width: 100px;">
+                                                    <t t-if="line.get('gl_balance')">
+                                                        <span t-esc="line.get('gl_balance')"/>
+                                                    </t>
+                                                    <t t-if="not line.get('gl_balance')">0.0</t>
+                                                </div>
+                                                <div class="act_as_cell amount" style="width: 100px;">
+                                                    <span t-esc="line.get('gl_ytd_balance') or 0.0"/>
+                                                </div>
                                             </div>
-                                            <div class="act_as_cell amount" style="width: 100px;">
-                                                <span t-esc="line.get('gl_foreign_balance') or 0.0"/>
-                                            </div>
-                                            <div class="act_as_cell" style="width: 50px;">
-                                                <span t-esc="line.get('curr_name') or '--'"/>
-                                            </div>
-                                            <div class="act_as_cell amount" style="width: 80px;">
-                                                <span t-esc="line.get('gl_currency_rate') or 0.0"/>
-                                            </div>
-                                            <div class="act_as_cell amount" style="width: 150px;">
-                                                <span t-esc="line.get('gl_revaluated_balance') or 0.0"/>
-                                            </div>
-                                            <div class="act_as_cell amount" style="width: 100px;">
-                                                <t t-if="line.get('gl_balance')">
-                                                    <span t-esc="line.get('gl_balance')"/>
-                                                </t>
-                                                <t t-if="not line.get('gl_balance')">0.0</t>
-                                            </div>
-                                            <div class="act_as_cell amount" style="width: 100px;">
-                                                <span t-esc="line.get('gl_ytd_balance') or 0.0"/>
-                                            </div>
-                                        </div>
+                                        </t>
                                     </t>
                                     <div class="act_as_row lines labels">
                                         <div class="act_as_cell"><b>TOTAL</b></div>
+                                        <div class="act_as_cell amount">
+                                            <t t-if="account.internal_type not in ['payable', 'receivable'] and sh_acc.curr_name_total_check">
+                                                <b>
+                                                    <span t-esc="sh_acc.gl_foreign_balance_total or 0.0"/>
+                                                </b>
+                                            </t>
+                                        </div>
                                         <div class="act_as_cell"></div>
-                                        <div class="act_as_cell"></div>
-                                        <div class="act_as_cell"></div>
+                                        <div class="act_as_cell amount">
+                                            <b>
+                                                <span t-esc="sh_acc.gl_currency_rate_total_check or 'Revaluation Rate not homogeneous'"/>
+                                            </b>
+                                        </div>
                                         <div class="act_as_cell amount">
                                             <b>
                                                 <span t-esc="sh_acc.gl_revaluated_balance_total or 0.0"/>

--- a/account_multicurrency_revaluation/report/unrealized_currency_gain_loss.xml
+++ b/account_multicurrency_revaluation/report/unrealized_currency_gain_loss.xml
@@ -38,60 +38,60 @@
                                         <div class="act_as_cell first_column amount" style="width: 100px;">Balance YTD</div>
                                         <div class="act_as_cell first_column amount" style="width: 100px;">Gain(+)/Loss(-) YTD</div>
                                     </div>
-                                    <t t-foreach="sh_acc.ordered_lines" t-as="line">
-                                        <t t-if="account.internal_type in ['payable', 'receivable']">
-                                            <div class="act_as_row lines">
-                                                <div class="act_as_cell">
-                                                    <span t-esc="line.get('name') or '--'"/>
-                                                </div>
-                                                <div class="act_as_cell amount" style="width: 100px;">
-                                                    <span t-esc="line.get('gl_foreign_balance') or 0.0"/>
-                                                </div>
-                                                <div class="act_as_cell" style="width: 50px;">
-                                                    <span t-esc="line.get('curr_name') or '--'"/>
-                                                </div>
-                                                <div class="act_as_cell amount" style="width: 80px;">
-                                                    <span t-esc="line.get('gl_currency_rate') or 0.0"/>
-                                                </div>
-                                                <div class="act_as_cell amount" style="width: 150px;">
-                                                    <span t-esc="line.get('gl_revaluated_balance') or 0.0"/>
-                                                </div>
-                                                <div class="act_as_cell amount" style="width: 100px;">
-                                                    <t t-if="line.get('gl_balance')">
-                                                        <span t-esc="line.get('gl_balance')"/>
-                                                    </t>
-                                                    <t t-if="not line.get('gl_balance')">0.0</t>
-                                                </div>
-                                                <div class="act_as_cell amount" style="width: 100px;">
-                                                    <span t-esc="line.get('gl_ytd_balance') or 0.0"/>
-                                                </div>
+                                </div>
+                                <t t-foreach="sh_acc.ordered_lines" t-as="line">
+                                    <t t-if="account.internal_type in ['payable', 'receivable']">
+                                        <div class="act_as_row lines">
+                                            <div class="act_as_cell">
+                                                <span t-esc="line.get('name') or '--'"/>
                                             </div>
-                                        </t>
+                                            <div class="act_as_cell amount" style="width: 100px;">
+                                                <span t-esc="line.get('gl_foreign_balance') or 0.0"/>
+                                            </div>
+                                            <div class="act_as_cell" style="width: 50px;">
+                                                <span t-esc="line.get('curr_name') or '--'"/>
+                                            </div>
+                                            <div class="act_as_cell amount" style="width: 80px;">
+                                                <span t-esc="line.get('gl_currency_rate') or 0.0"/>
+                                            </div>
+                                            <div class="act_as_cell amount" style="width: 150px;">
+                                                <span t-esc="line.get('gl_revaluated_balance') or 0.0"/>
+                                            </div>
+                                            <div class="act_as_cell amount" style="width: 100px;">
+                                                <t t-if="line.get('gl_balance')">
+                                                    <span t-esc="line.get('gl_balance')"/>
+                                                </t>
+                                                <t t-if="not line.get('gl_balance')">0.0</t>
+                                            </div>
+                                            <div class="act_as_cell amount" style="width: 100px;">
+                                                <span t-esc="line.get('gl_ytd_balance') or 0.0"/>
+                                            </div>
+                                        </div>
                                     </t>
-                                    <div class="act_as_row lines labels">
-                                        <div class="act_as_cell"><b>TOTAL</b></div>
-                                        <div class="act_as_cell amount">
-                                            <t t-if="account.internal_type not in ['payable', 'receivable']">
-                                                <strong t-esc="sh_acc.gl_foreign_balance_total or 0.0"/>
-                                            </t>
-                                        </div>
-                                        <div class="act_as_cell" style="width: 50px;">
-                                            <t t-if="account.internal_type not in ['payable', 'receivable']">
-                                                <strong t-esc="sh_acc.ordered_lines[0].get('curr_name')"/>
-                                            </t>
-                                        </div>
-                                        <div class="act_as_cell amount">
-                                            <strong t-esc="sh_acc.ordered_lines[0].get('gl_currency_rate')"/>
-                                        </div>
-                                        <div class="act_as_cell amount">
-                                            <strong t-esc="sh_acc.gl_revaluated_balance_total or 0.0"/>
-                                        </div>
-                                        <div class="act_as_cell amount">
-                                            <strong t-esc="sh_acc.gl_balance_total or 0.0"/>
-                                        </div>
-                                        <div class="act_as_cell amount">
-                                            <strong t-esc="sh_acc.gl_ytd_balance_total or 0.0"/>
-                                        </div>
+                                </t>
+                                <div class="act_as_row lines labels">
+                                    <div class="act_as_cell"><b>TOTAL</b></div>
+                                    <div class="act_as_cell amount">
+                                        <t t-if="account.internal_type not in ['payable', 'receivable']">
+                                            <strong t-esc="sh_acc.gl_foreign_balance_total or 0.0"/>
+                                        </t>
+                                    </div>
+                                    <div class="act_as_cell" style="width: 50px;">
+                                        <t t-if="account.internal_type not in ['payable', 'receivable']">
+                                            <strong t-esc="sh_acc.ordered_lines[0].get('curr_name')"/>
+                                        </t>
+                                    </div>
+                                    <div class="act_as_cell amount">
+                                        <strong t-esc="sh_acc.ordered_lines[0].get('gl_currency_rate')"/>
+                                    </div>
+                                    <div class="act_as_cell amount">
+                                        <strong t-esc="sh_acc.gl_revaluated_balance_total or 0.0"/>
+                                    </div>
+                                    <div class="act_as_cell amount">
+                                        <strong t-esc="sh_acc.gl_balance_total or 0.0"/>
+                                    </div>
+                                    <div class="act_as_cell amount">
+                                        <strong t-esc="sh_acc.gl_ytd_balance_total or 0.0"/>
                                     </div>
                                 </div>
                             </div>

--- a/account_multicurrency_revaluation/report/unrealized_currency_gain_loss.xml
+++ b/account_multicurrency_revaluation/report/unrealized_currency_gain_loss.xml
@@ -72,31 +72,21 @@
                                         <div class="act_as_cell"><b>TOTAL</b></div>
                                         <div class="act_as_cell amount">
                                             <t t-if="account.internal_type not in ['payable', 'receivable'] and sh_acc.curr_name_total_check">
-                                                <b>
-                                                    <span t-esc="sh_acc.gl_foreign_balance_total or 0.0"/>
-                                                </b>
+                                                <strong t-esc="sh_acc.gl_foreign_balance_total or 0.0"/>
                                             </t>
                                         </div>
                                         <div class="act_as_cell"></div>
                                         <div class="act_as_cell amount">
-                                            <b>
-                                                <span t-esc="sh_acc.gl_currency_rate_total_check or 'Revaluation Rate not homogeneous'"/>
-                                            </b>
+                                            <strong t-esc="sh_acc.gl_currency_rate_total_check or 'Revaluation Rate not homogeneous'"/>
                                         </div>
                                         <div class="act_as_cell amount">
-                                            <b>
-                                                <span t-esc="sh_acc.gl_revaluated_balance_total or 0.0"/>
-                                            </b>
+                                            <strong t-esc="sh_acc.gl_revaluated_balance_total or 0.0"/>
                                         </div>
                                         <div class="act_as_cell amount">
-                                            <b>
-                                                <span t-esc="sh_acc.gl_balance_total or 0.0"/>
-                                            </b>
+                                            <strong t-esc="sh_acc.gl_balance_total or 0.0"/>
                                         </div>
                                         <div class="act_as_cell amount">
-                                            <b>
-                                                <span t-esc="sh_acc.gl_ytd_balance_total or 0.0"/>
-                                            </b>
+                                            <strong t-esc="sh_acc.gl_ytd_balance_total or 0.0"/>
                                         </div>
                                     </div>
                                 </div>

--- a/account_multicurrency_revaluation/report/unrealized_currency_gain_loss.xml
+++ b/account_multicurrency_revaluation/report/unrealized_currency_gain_loss.xml
@@ -71,13 +71,17 @@
                                     <div class="act_as_row lines labels">
                                         <div class="act_as_cell"><b>TOTAL</b></div>
                                         <div class="act_as_cell amount">
-                                            <t t-if="account.internal_type not in ['payable', 'receivable'] and sh_acc.curr_name_total_check">
+                                            <t t-if="account.internal_type not in ['payable', 'receivable']">
                                                 <strong t-esc="sh_acc.gl_foreign_balance_total or 0.0"/>
                                             </t>
                                         </div>
-                                        <div class="act_as_cell"></div>
+                                        <div class="act_as_cell" style="width: 50px;">
+                                            <t t-if="account.internal_type not in ['payable', 'receivable']">
+                                                <strong t-esc="sh_acc.ordered_lines[0].get('curr_name')"/>
+                                            </t>
+                                        </div>
                                         <div class="act_as_cell amount">
-                                            <strong t-esc="sh_acc.gl_currency_rate_total_check or 'Revaluation Rate not homogeneous'"/>
+                                            <strong t-esc="sh_acc.ordered_lines[0].get('gl_currency_rate')"/>
                                         </div>
                                         <div class="act_as_cell amount">
                                             <strong t-esc="sh_acc.gl_revaluated_balance_total or 0.0"/>

--- a/account_multicurrency_revaluation/wizard/print_currency_unrealized_report_view.xml
+++ b/account_multicurrency_revaluation/wizard/print_currency_unrealized_report_view.xml
@@ -29,9 +29,10 @@
         </record>
 
         <menuitem
-                name="Currency Unrealized"
+                name="Currency revaluation"
                 action="currency_urealized_report_action_wizard"
-                parent="account.menu_finance_reports"
+                parent="account_financial_report_qweb.menu_oca_reports"
+                sequence="50"
                 id="currency_unrealized_report_wizard_menu"/>
 
 </odoo>

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,2 +1,3 @@
+account-financial-reporting
 account-financial-tools
 account-invoicing


### PR DESCRIPTION
- Change the grouping rule for bank account in the report
  -  The result for not in ['payable', 'receivable'] should be printed only the total 
     - with _Curr. Balance YTD_ and _Revaluation Rate_ only if they are consistent

- Changing report name from _Unrealized currency report_ to _Currency revaluation report_

#### Before
![image](https://user-images.githubusercontent.com/32262135/52963034-09476000-339f-11e9-8240-82b59476601e.png)


#### After

![image](https://user-images.githubusercontent.com/32262135/53083845-ec766e00-34ff-11e9-9aa2-67c47272efce.png)




-----

### Menuitem changing 

- Moving to the right _Currency Unrealized_ menu item (on the same indent as _Aged Partner Balance_) (so in the _OCA accounting reports_ category )

- Changing _Currency Unrealized_ menu item name to _Currency revaluation_

#### Before
![image](https://user-images.githubusercontent.com/32262135/52962467-9c7f9600-339d-11e9-89be-bd986643fee9.png)

#### After
![image](https://user-images.githubusercontent.com/32262135/52962607-f97b4c00-339d-11e9-939a-7910b510af2a.png)




