### PR TITLE
[10.0] FIX bug rounding debit/credit

### DIFF
--- a/account_cutoff_accrual_dates/models/account_cutoff.py
+++ b/account_cutoff_accrual_dates/models/account_cutoff.py
@@ -5,7 +5,6 @@
 
 from odoo import models, fields, api, _
 from odoo.exceptions import UserError
-from odoo.tools import float_round
 
 
 class AccountCutoff(models.Model):
@@ -44,9 +43,7 @@ class AccountCutoff(models.Model):
             'Should never happen. Total days should always be > 0'
         cutoff_amount = (aml.credit - aml.debit) *\
             prepaid_days / float(total_days)
-        precision_rounding = self.company_currency_id.rounding
-        cutoff_amount = float_round(
-            cutoff_amount, precision_rounding=precision_rounding)
+        cutoff_amount = self.company_currency_id.round(cutoff_amount)
         # we use account mapping here
         if aml.account_id.id in mapping:
             cutoff_account_id = mapping[aml.account_id.id]
@@ -94,8 +91,7 @@ class AccountCutoff(models.Model):
                         raise UserError(_(
                             "Missing 'Accrued Revenue Tax Account' "
                             "on tax '%s'") % tax.display_name)
-                tamount = float_round(
-                    tax_line['amount'], precision_rounding=precision_rounding)
+                tamount = self.company_currency_id.round(tax_line['amount'])
                 res['tax_line_ids'].append((0, 0, {
                     'tax_id': tax_line['id'],
                     'base': cutoff_amount,

--- a/account_cutoff_base/models/account_cutoff.py
+++ b/account_cutoff_base/models/account_cutoff.py
@@ -5,7 +5,6 @@
 from odoo import models, fields, api, _
 from odoo.exceptions import UserError
 from dateutil.relativedelta import relativedelta
-from odoo.tools import float_round
 
 
 class AccountCutoff(models.Model):
@@ -140,9 +139,8 @@ class AccountCutoff(models.Model):
         amount_total = 0
         move_label = self.move_label
         merge_keys = self._get_merge_keys()
-        prec_r = self.company_currency_id.rounding
         for merge_values, amount in to_provision.items():
-            amount = float_round(amount, precision_rounding=prec_r)
+            amount = self.company_currency_id.round(amount)
             vals = {
                 'name': move_label,
                 'debit': amount < 0 and amount * -1 or 0,
@@ -154,8 +152,8 @@ class AccountCutoff(models.Model):
             amount_total += amount
 
         # add counter-part
-        counterpart_amount = float_round(
-            amount_total * -1, precision_rounding=prec_r)
+        counterpart_amount = self.company_currency_id.round(
+            amount_total * -1)
         movelines_to_create.append((0, 0, {
             'account_id': self.cutoff_account_id.id,
             'name': move_label,

--- a/account_cutoff_base/models/account_cutoff.py
+++ b/account_cutoff_base/models/account_cutoff.py
@@ -5,6 +5,7 @@
 from odoo import models, fields, api, _
 from odoo.exceptions import UserError
 from dateutil.relativedelta import relativedelta
+from odoo.tools import float_round
 
 
 class AccountCutoff(models.Model):
@@ -139,7 +140,9 @@ class AccountCutoff(models.Model):
         amount_total = 0
         move_label = self.move_label
         merge_keys = self._get_merge_keys()
+        prec_r = self.company_currency_id.rounding
         for merge_values, amount in to_provision.items():
+            amount = float_round(amount, precision_rounding=prec_r)
             vals = {
                 'name': move_label,
                 'debit': amount < 0 and amount * -1 or 0,
@@ -151,7 +154,8 @@ class AccountCutoff(models.Model):
             amount_total += amount
 
         # add counter-part
-        counterpart_amount = amount_total * -1
+        counterpart_amount = float_round(
+            amount_total * -1, precision_rounding=prec_r)
         movelines_to_create.append((0, 0, {
             'account_id': self.cutoff_account_id.id,
             'name': move_label,

--- a/account_cutoff_prepaid/models/account_cutoff.py
+++ b/account_cutoff_prepaid/models/account_cutoff.py
@@ -4,6 +4,7 @@
 
 from odoo import models, fields, api, _
 from odoo.exceptions import UserError, ValidationError
+from odoo.tools import float_round
 
 
 class AccountCutoff(models.Model):
@@ -88,6 +89,9 @@ class AccountCutoff(models.Model):
             'Should never happen. Total days should always be > 0'
         cutoff_amount = (aml.debit - aml.credit) *\
             prepaid_days / float(total_days)
+        cutoff_amount = float_round(
+            cutoff_amount,
+            precision_rounding=self.company_currency_id.rounding)
         # we use account mapping here
         if aml.account_id.id in mapping:
             cutoff_account_id = mapping[aml.account_id.id]

--- a/account_cutoff_prepaid/models/account_cutoff.py
+++ b/account_cutoff_prepaid/models/account_cutoff.py
@@ -4,7 +4,6 @@
 
 from odoo import models, fields, api, _
 from odoo.exceptions import UserError, ValidationError
-from odoo.tools import float_round
 
 
 class AccountCutoff(models.Model):
@@ -89,9 +88,7 @@ class AccountCutoff(models.Model):
             'Should never happen. Total days should always be > 0'
         cutoff_amount = (aml.debit - aml.credit) *\
             prepaid_days / float(total_days)
-        cutoff_amount = float_round(
-            cutoff_amount,
-            precision_rounding=self.company_currency_id.rounding)
+        cutoff_amount = self.company_currency_id.round(cutoff_amount)
         # we use account mapping here
         if aml.account_id.id in mapping:
             cutoff_account_id = mapping[aml.account_id.id]


### PR DESCRIPTION
In the DB, the debit or credit should look like 244.25 or 244.45000000000005, but should NEVER look like 244.45770338474394 because it leads to annoying problems in accounting reports. For that, we need to round before doing the create of account.move.line in DB.

This is a very important bug, but leads to total debit != total credit in a balance ! More explanations to come.
Maybe we can improve this fix to also round in cutoff lines.