### PR TITLE
[12.0][FIX] account_cutoff_base: moved cutoff menu in submenu "menu_finance_entries"

### DIFF
--- a/account_cutoff_base/views/account_cutoff.xml
+++ b/account_cutoff_base/views/account_cutoff.xml
@@ -7,9 +7,8 @@
 <odoo>
 
     <menuitem id="cutoff_menu"
-            parent="account.menu_finance"
+            parent="account.menu_finance_entries"
             name="Cut-offs"
-            sequence="5"
             groups="account.group_account_user,account.group_account_manager"/>
 
     <!-- Form view -->


### PR DESCRIPTION
Behavior before this PR:
The problem is present only if account_accountant module is installed (enterprise version)
account_accountant move the "Invoicing"'s submenu into new menu "Accounting".

This module create the submenu "Cut-offs" on menu "Invoicing" .

The final result is to have two menu: "Accounting" with all standard menus and the old menu "Invoicing" with only submenu "Cut-offs".

Behavior after this PR:
Moved submenu "Cut-offs" into a submenu "Accounting" (one of the submenus natively moved by account_accountant).