### PR TITLE
[RFR] [FIX] 12.0 remove duplicate demo data entry from account_multicurrency_revaluation

### DIFF
--- a/account_multicurrency_revaluation/demo/account_demo.xml
+++ b/account_multicurrency_revaluation/demo/account_demo.xml
@@ -125,9 +125,4 @@
         <field name="type">sale</field>
         <field name="company_id" ref="res_company_reval" />
     </record>
-    <record id="account_payment_method_manual_in" model="account.payment.method">
-        <field name="name">Manual</field>
-        <field name="code">manual</field>
-        <field name="payment_type">inbound</field>
-    </record>
 </odoo>

--- a/account_multicurrency_revaluation/tests/test_currency_revaluation.py
+++ b/account_multicurrency_revaluation/tests/test_currency_revaluation.py
@@ -73,8 +73,8 @@ class TestCurrencyRevaluation(SavepointCase):
         # Validate invoice
         invoice.action_invoice_open()
 
-        payment_method = ref('account_multicurrency_revaluation.'
-                             'account_payment_method_manual_in')
+        payment_method = ref(
+            'account.account_payment_method_manual_in')
 
         # Register partial payment
         payment = cls.env['account.payment'].create({
@@ -359,8 +359,8 @@ class TestCurrencyRevaluation(SavepointCase):
             'currency_id': eur_currency.id,
         })
         euro_bank.default_debit_account_id.currency_revaluation = True
-        payment_method = self.env.ref('account_multicurrency_revaluation.'
-                                      'account_payment_method_manual_in')
+        payment_method = self.env.ref(
+            'account.account_payment_method_manual_in')
 
         # Register partial payment
         payment = self.env['account.payment'].create({


### PR DESCRIPTION
Unnecessary duplicate demo data entry which is already present in odoo's account module:
https://github.com/odoo/odoo/blob/12.0/addons/account/data/account_data.xml#L100-L104

Also refer to the appropriate xml id in the test.