### PR TITLE
[12.0] FIX account_cutoff_accrual_dates: compute Accrual On Taxes only if enabled

### DIFF
--- a/account_cutoff_accrual_base/models/account_cutoff.py
+++ b/account_cutoff_accrual_base/models/account_cutoff.py
@@ -12,7 +12,7 @@ class AccountCutOff(models.Model):
     @api.model
     def _default_cutoff_account_id(self):
         account_id = super(AccountCutOff, self)._default_cutoff_account_id()
-        cutoff_type = self.env.context.get('default_cutoff_type')
+        cutoff_type = self.env.context.get('cutoff_type')
         company = self.env.user.company_id
         if cutoff_type == 'accrued_expense':
             account_id = company.default_accrued_expense_account_id.id or False

--- a/account_cutoff_accrual_base/tests/test_account_cutoff.py
+++ b/account_cutoff_accrual_base/tests/test_account_cutoff.py
@@ -9,18 +9,17 @@ class TestAccountCutoff(TransactionCase):
 
     def test_default_cutoff_account_id(self):
         company = self.env.user.company_id
-        default_accrued_expense_account_id = \
-            company.default_accrued_expense_account_id.id or False
-        default_accrued_revenue_account_id = \
-            company.default_accrued_revenue_account_id.id or False
+        random_account = self.env['account.account'].search([])[0]
+        company.default_accrued_expense_account_id = random_account.id
+        company.default_accrued_revenue_account_id = random_account.id
 
         account_id = self.env['account.cutoff'].with_context(
-            default_cutoff_type='accrued_expense')._default_cutoff_account_id()
-        self.assertEqual(account_id, default_accrued_expense_account_id,
+            cutoff_type='accrued_expense')._default_cutoff_account_id()
+        self.assertEqual(account_id, random_account.id,
                          'The account must be equals to %s' %
-                         default_accrued_expense_account_id)
+                         random_account.id)
         account_id = self.env['account.cutoff'].with_context(
-            default_cutoff_type='accrued_revenue')._default_cutoff_account_id()
-        self.assertEqual(account_id, default_accrued_revenue_account_id,
+            cutoff_type='accrued_revenue')._default_cutoff_account_id()
+        self.assertEqual(account_id, random_account.id,
                          'The account must be equals to %s' %
-                         default_accrued_revenue_account_id)
+                         random_account.id)

--- a/account_cutoff_accrual_dates/models/account_cutoff.py
+++ b/account_cutoff_accrual_dates/models/account_cutoff.py
@@ -67,7 +67,7 @@ class AccountCutoff(models.Model):
             'tax_line_ids': [],
             }
 
-        if aml.tax_ids:
+        if aml.tax_ids and self.company_id.accrual_taxes:
             # It won't work with price-included taxes
             tax_res = aml.tax_ids.compute_all(
                 cutoff_amount, product=aml.product_id, partner=aml.partner_id)


### PR DESCRIPTION
and

account_cutoff_accrual_base: default value not set due to wrong context value