### PR TITLE
[10.0][ADD] account_cutoff_base - removing account_type domains on analytic account fields

### DIFF
--- a/account_cutoff_base/models/account_cutoff.py
+++ b/account_cutoff_base/models/account_cutoff.py
@@ -293,8 +293,7 @@ class AccountCutoffLine(models.Model):
         related='cutoff_account_id.code',
         string='Cut-off Account', readonly=True)
     analytic_account_id = fields.Many2one(
-        'account.analytic.account', string='Analytic Account',
-        domain=[('account_type', '!=', 'closed')], readonly=True)
+        'account.analytic.account', string='Analytic Account', readonly=True)
     analytic_account_code = fields.Char(
         related='analytic_account_id.code',
         string='Analytic Account', readonly=True)
@@ -332,8 +331,7 @@ class AccountCutoffTaxLine(models.Model):
         'account.account', string='Cut-off Account',
         domain=[('deprecated', '=', False)], required=True, readonly=True)
     analytic_account_id = fields.Many2one(
-        'account.analytic.account', string='Analytic Account',
-        domain=[('account_type', '!=', 'closed')], readonly=True)
+        'account.analytic.account', string='Analytic Account', readonly=True)
     base = fields.Monetary(
         string='Base', currency_field='currency_id',
         readonly=True, help="Base Amount in the currency of the PO.")


### PR DESCRIPTION
Due to [this commit](https://github.com/odoo/odoo/commit/a57592abe4e8ac3bac04cbd19eeac88a163aaf7e) in odoo code, `account_type` field does not exist anymore.
This pr removes reference to this field in module `account_cutoff_base`.