### PR TITLE
[REF] account_multicurrency_revaluation: Set revaluation date correctly

### DIFF
--- a/account_multicurrency_revaluation/wizard/wizard_currency_revaluation_view.xml
+++ b/account_multicurrency_revaluation/wizard/wizard_currency_revaluation_view.xml
@@ -25,7 +25,7 @@
                     <label string="%%(rate)s : Value of rate applied during revaluation"/>
                 </group>
                 <footer>
-                    <button name="revaluate_currency" type="object" string="_Validate" class="oe_highlight"/>
+                    <button name="revaluate_currency" type="object" string="_Validate" class="oe_highlight" context="{'date': revaluation_date}"/>
                     <button string="Cancel" class="oe_link" special="cancel" />
                 </footer>
             </form>


### PR DESCRIPTION
Set the revaluation date on the context when calling the
`revaluate_currency` method on the wizard view, to correctly use the
rate of the input date, because without this change, the rate used for
the creation of the move and lines would use the creation date, instead
of the required date.