### PR TITLE
[13.0][FIX] account_cutoff_base: res company

### DIFF
--- a/account_cutoff_base/models/__init__.py
+++ b/account_cutoff_base/models/__init__.py
@@ -1,3 +1,3 @@
-from . import account_cutoff
 from . import company
+from . import account_cutoff
 from . import res_config_settings


### PR DESCRIPTION
company.py should be loaded first due to used field
default_cutoff_move_partner on account_cutoff.py