### PR TITLE
[10.0] account_cutoff_base: backport option move_partner from v13 to v10

### DIFF
--- a/account_cutoff_base/models/__init__.py
+++ b/account_cutoff_base/models/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from . import account_cutoff
 from . import company
 from . import account_config_settings
+from . import account_cutoff

--- a/account_cutoff_base/models/account_config_settings.py
+++ b/account_cutoff_base/models/account_config_settings.py
@@ -10,3 +10,5 @@ class AccountConfigSettings(models.TransientModel):
 
     default_cutoff_journal_id = fields.Many2one(
         related='company_id.default_cutoff_journal_id')
+    default_cutoff_move_partner = fields.Boolean(
+        related='company_id.default_cutoff_move_partner')

--- a/account_cutoff_base/models/account_cutoff.py
+++ b/account_cutoff_base/models/account_cutoff.py
@@ -45,6 +45,10 @@ class AccountCutoff(models.Model):
         return self.env.user.company_id.default_cutoff_journal_id
 
     @api.model
+    def _default_move_partner(self):
+        return self.env.user.company_id.default_cutoff_move_partner
+
+    @api.model
     def _default_cutoff_date(self):
         company = self.env.user.company_id
         today_str = fields.Date.context_today(self)
@@ -79,6 +83,9 @@ class AccountCutoff(models.Model):
         help="This label will be written in the 'Name' field of the "
         "Cut-off Account Move Lines and in the 'Reference' field of "
         "the Cut-off Account Move.")
+    move_partner = fields.Boolean(
+        string="Partner on Move Line",
+        default=lambda self: self._default_move_partner())
     cutoff_account_id = fields.Many2one(
         'account.account', string='Cut-off Account',
         domain=[('deprecated', '=', False)],
@@ -131,7 +138,7 @@ class AccountCutoff(models.Model):
         same values for these fields will be merged.
         The list must at least contain account_id.
         """
-        return ['account_id', 'analytic_account_id']
+        return ['partner_id', 'account_id', 'analytic_account_id']
 
     def _prepare_move(self, to_provision):
         self.ensure_one()
@@ -179,7 +186,9 @@ class AccountCutoff(models.Model):
         If you override this, the added fields must also be
         added in an override of _get_merge_keys.
         """
+        partner_id = cutoff_line.partner_id.id or False
         return {
+            'partner_id': self.move_partner and partner_id or False,
             'account_id': cutoff_line.cutoff_account_id.id,
             'analytic_account_id': cutoff_line.analytic_account_id.id,
             'amount': cutoff_line.cutoff_amount,
@@ -191,6 +200,7 @@ class AccountCutoff(models.Model):
         See _prepare_provision_line for more info.
         """
         return {
+            'partner_id': False,
             'account_id': cutoff_tax_line.cutoff_account_id.id,
             'analytic_account_id': cutoff_tax_line.analytic_account_id.id,
             'amount': cutoff_tax_line.cutoff_amount,

--- a/account_cutoff_base/models/company.py
+++ b/account_cutoff_base/models/company.py
@@ -10,3 +10,5 @@ class ResCompany(models.Model):
 
     default_cutoff_journal_id = fields.Many2one(
         'account.journal', string='Default Cut-off Journal')
+    default_cutoff_move_partner = fields.Boolean(
+        string="Partner on Move Line by Default")

--- a/account_cutoff_base/views/account_config_settings.xml
+++ b/account_cutoff_base/views/account_config_settings.xml
@@ -15,6 +15,7 @@
         <group name="accounting" position="after">
             <group name="cutoff" string="Cut-offs">
                 <field name="default_cutoff_journal_id" />
+                <field name="default_cutoff_move_partner" />
             </group>
         </group>
     </field>

--- a/account_cutoff_base/views/account_cutoff.xml
+++ b/account_cutoff_base/views/account_cutoff.xml
@@ -53,6 +53,7 @@
                         <field name="cutoff_journal_id" required="1"/>
                         <field name="cutoff_account_id" required="1"/>
                         <field name="move_label" required="1"/>
+                        <field name="move_partner"/>
                         <field name="move_id"/>
                     </group>
                 </group>


### PR DESCRIPTION
This is a simple backport of this v13 commit : https://github.com/OCA/account-closing/commit/4f2af3bce4912174ff7c2dc6118a5b68e0a5fbbd

It adds an option to split the generated account.move per partner.