### PR TITLE
[12.0][IMP] account_multicurrency_revaluation

### DIFF
--- a/account_multicurrency_revaluation/model/account.py
+++ b/account_multicurrency_revaluation/model/account.py
@@ -1,4 +1,5 @@
 # Copyright 2012-2018 Camptocamp SA
+# Copyright 2020 CorporateHub (https://corporatehub.eu)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import models, fields, api
@@ -17,17 +18,16 @@ class AccountAccount(models.Model):
     _inherit = 'account.account'
 
     currency_revaluation = fields.Boolean(
-        string="Allow Currency revaluation",
-        default=False,
+        string="Allow currency revaluation",
     )
 
     _sql_mapping = {
-        'balance': "COALESCE(SUM(debit),0) - COALESCE(SUM(credit), 0) as "
-                   "balance",
+        'balance':
+            "COALESCE(SUM(debit),0) - COALESCE(SUM(credit), 0) as balance",
         'debit': "COALESCE(SUM(debit), 0) as debit",
         'credit': "COALESCE(SUM(credit), 0) as credit",
-        'foreign_balance': "COALESCE(SUM(amount_currency), 0) as foreign_"
-                           "balance",
+        'foreign_balance':
+            "COALESCE(SUM(amount_currency), 0) as foreign_balance",
     }
 
     def init(self):
@@ -60,68 +60,83 @@ class AccountAccount(models.Model):
 
     @api.multi
     def _revaluation_query(self, revaluation_date):
-
         tables, where_clause, where_clause_params = \
             self.env['account.move.line']._query_get()
 
-        query = ("with amount as ( SELECT aml.account_id, aml.partner_id, "
-                 "aml.currency_id, aml.debit, aml.credit, aml.amount_currency "
-                 "FROM account_move_line aml LEFT JOIN "
-                 "account_partial_reconcile aprc ON (aml.balance < 0 "
-                 "AND aml.id = aprc.credit_move_id) LEFT JOIN "
-                 "account_move_line amlcf ON (aml.balance < 0 "
-                 "AND aprc.debit_move_id = amlcf.id "
-                 "AND amlcf.date < %s ) LEFT JOIN "
-                 "account_partial_reconcile aprd ON (aml.balance > 0 "
-                 "AND aml.id = aprd.debit_move_id) LEFT JOIN "
-                 "account_move_line amldf ON (aml.balance > 0 "
-                 "AND aprd.credit_move_id = amldf.id "
-                 "AND amldf.date < %s ) "
-                 "WHERE aml.account_id IN %s "
-                 "AND aml.date <= %s "
-                 "AND aml.currency_id IS NOT NULL "
-                 "GROUP BY aml.id "
-                 "HAVING aml.full_reconcile_id IS NULL "
-                 "OR (MAX(amldf.id) IS NULL AND MAX(amlcf.id) IS NULL)"
-                 ") SELECT account_id as id, partner_id, currency_id, " +
-                 ', '.join(self._sql_mapping.values()) +
-                 " FROM amount " +
-                 (("WHERE " + where_clause) if where_clause else " ") +
-                 " GROUP BY account_id, currency_id, partner_id")
+        query = """
+WITH amount AS (
+    SELECT
+        aml.account_id,
+        CASE WHEN aat.type IN ('payable', 'receivable')
+            THEN aml.partner_id
+            ELSE NULL
+        END AS partner_id,
+        aml.currency_id,
+        aml.debit,
+        aml.credit,
+        aml.amount_currency
+    FROM account_move_line aml
+    INNER JOIN account_account acc ON aml.account_id = acc.id
+    INNER JOIN account_account_type aat ON acc.user_type_id = aat.id
+    LEFT JOIN account_partial_reconcile aprc
+        ON (aml.balance < 0 AND aml.id = aprc.credit_move_id)
+    LEFT JOIN account_move_line amlcf
+        ON (
+            aml.balance < 0
+            AND aprc.debit_move_id = amlcf.id
+            AND amlcf.date < %s
+        )
+    LEFT JOIN account_partial_reconcile aprd
+        ON (aml.balance > 0 AND aml.id = aprd.debit_move_id)
+    LEFT JOIN account_move_line amldf
+        ON (
+            aml.balance > 0
+            AND aprd.credit_move_id = amldf.id
+            AND amldf.date < %s
+        )
+    WHERE
+        aml.account_id IN %s
+        AND aml.date <= %s
+        AND aml.currency_id IS NOT NULL
+    GROUP BY
+        aat.type,
+        aml.id
+    HAVING
+        aml.full_reconcile_id IS NULL
+        OR (MAX(amldf.id) IS NULL AND MAX(amlcf.id) IS NULL)
+)
+SELECT
+    account_id as id,
+    partner_id,
+    currency_id,
+""" + ', '.join(self._sql_mapping.values()) + """
+FROM amount
+""" + (('WHERE ' + where_clause) if where_clause else '') + """
+GROUP BY account_id, currency_id, partner_id
+        """
 
-        params = []
-        params.append(revaluation_date)
-        params.append(revaluation_date)
-        params.append(tuple(self.ids))
-        params.append(revaluation_date)
-        params += where_clause_params
+        params = [
+            revaluation_date,
+            revaluation_date,
+            tuple(self.ids),
+            revaluation_date,
+            *where_clause_params,
+        ]
+
         return query, params
 
     @api.multi
     def compute_revaluations(self, revaluation_date):
-        accounts = {}
-        # compute for each account the balance/debit/credit from the move lines
         query, params = self._revaluation_query(revaluation_date)
         self.env.cr.execute(query, params)
-
         lines = self.env.cr.dictfetchall()
-        rec_pay = [self.env.ref("account.data_account_type_receivable").id,
-                   self.env.ref("account.data_account_type_payable").id]
 
+        data = {}
         for line in lines:
-            # generate a tree
-            # - account_id
-            # -- currency_id
-            # --- partner_id
-            # ----- balances
             account_id, currency_id, partner_id = \
                 line['id'], line['currency_id'], line['partner_id']
-            account_type = self.env['account.account'].browse(
-                account_id).user_type_id
-            accounts.setdefault(account_id, {})
-            partner_id = partner_id if account_type.id in rec_pay else False
-            accounts[account_id].setdefault(partner_id, {})
-            accounts[account_id][partner_id].setdefault(currency_id, {})
-            accounts[account_id][partner_id][currency_id] = line
-
-        return accounts
+            data.setdefault(account_id, {})
+            data[account_id].setdefault(partner_id, {})
+            data[account_id][partner_id].setdefault(currency_id, {})
+            data[account_id][partner_id][currency_id] = line
+        return data

--- a/account_multicurrency_revaluation/readme/CONTRIBUTORS.rst
+++ b/account_multicurrency_revaluation/readme/CONTRIBUTORS.rst
@@ -12,3 +12,6 @@
 * Vincent Renaville
 * Yannick Vaucher
 * Akim Juillerat
+* `CorporateHub <https://corporatehub.eu/>`__
+
+  * Alexey Pelykh <alexey.pelykh@corphub.eu>

--- a/account_multicurrency_revaluation/readme/INSTALL.rst
+++ b/account_multicurrency_revaluation/readme/INSTALL.rst
@@ -1,7 +1,0 @@
-To install this module, you need to:
-
-* clone the branch 11.0 of the repository https://github.com/OCA/account-closing
-* add the path to this repository in your configuration (addons-path)
-* update the module list
-* search for "Multicurrency revaluation" in your addons
-* install the module

--- a/account_multicurrency_revaluation/readme/USAGE.rst
+++ b/account_multicurrency_revaluation/readme/USAGE.rst
@@ -6,10 +6,3 @@ To use this module, you need to:
   *Allow currency revaluation* checked.
 * Open the report through the following menu:
   Accounting > Reporting > Legal Reports > Accounting Reports > Print Currency Unrealized
-
-
-.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
-   :alt: Try me on Runbot
-   :target: https://runbot.odoo-community.org/runbot/89/11.0
-
-

--- a/account_multicurrency_revaluation/tests/__init__.py
+++ b/account_multicurrency_revaluation/tests/__init__.py
@@ -1,2 +1,3 @@
+from . import test_account_account
 from . import test_currency_revaluation
 from . import test_currency_revaluation_report

--- a/account_multicurrency_revaluation/tests/test_account_account.py
+++ b/account_multicurrency_revaluation/tests/test_account_account.py
@@ -1,0 +1,47 @@
+# Copyright 2020 CorporateHub (https://corporatehub.eu)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo.tests import common
+
+
+class TestAccountAccount(common.SavepointCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.AccountAccount = cls.env['account.account']
+        cls.account_type_current_liabilities = cls.env.ref(
+            'account.data_account_type_current_liabilities'
+        )
+        cls.account_type_liquidity = cls.env.ref(
+            'account.data_account_type_liquidity'
+        )
+        cls.company = cls.env.ref(
+            'account_multicurrency_revaluation.res_company_reval'
+        )
+
+        cls.env.user.write({
+            'company_ids': [(4, cls.company.id, False)]
+        })
+        cls.env.user.company_id = cls.company
+
+    def test_currency_revaluation_field(self):
+        with common.Form(
+                self.AccountAccount,
+                view='account.view_account_form') as form:
+            form.name = 'Test Account'
+            form.company_id = self.company
+            form.code = 'TEST'
+            form.user_type_id = self.account_type_current_liabilities
+            account = form.save()
+
+        self.assertFalse(account.currency_revaluation)
+
+        with common.Form(
+                account,
+                view='account.view_account_form') as form:
+            form.user_type_id = self.account_type_liquidity
+            account = form.save()
+
+        self.assertTrue(account.currency_revaluation)

--- a/account_multicurrency_revaluation/tests/test_currency_revaluation.py
+++ b/account_multicurrency_revaluation/tests/test_currency_revaluation.py
@@ -1,203 +1,31 @@
 # Copyright 2012-2018 Camptocamp SA
+# Copyright 2020 CorporateHub (https://corporatehub.eu)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from datetime import timedelta
-from odoo.tests.common import SavepointCase
+
+from odoo.exceptions import Warning
+from odoo.tests import common
 from odoo import fields
 
 
-class TestCurrencyRevaluation(SavepointCase):
+class TestCurrencyRevaluation(common.SavepointCase):
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        ref = cls.env.ref
 
-        # Set currency EUR on company
-        cls.company = ref(
-            'account_multicurrency_revaluation.res_company_reval')
+        cls.today = fields.Date.today()
+        cls.company = cls.env.ref(
+            'account_multicurrency_revaluation.res_company_reval'
+        )
         cls.env.user.write({
             'company_ids': [(4, cls.company.id, False)]
         })
         cls.env.user.company_id = cls.company
-
-        cls.reval_journal = ref(
-            'account_multicurrency_revaluation.reval_journal')
-
-        sales_journal = ref('account_multicurrency_revaluation.sales_journal')
-
-        receivable_acc = ref(
-            'account_multicurrency_revaluation.demo_acc_receivable')
-        receivable_acc.write({'reconcile': True})
-        payable_acc = ref(
-            'account_multicurrency_revaluation.demo_acc_payable')
-
-        revenue_acc = ref('account_multicurrency_revaluation.'
-                          'demo_acc_revenue')
-
-        # create invoice in USD
-        usd_currency = ref('base.USD')
-
-        bank_journal_usd = ref(
-            'account_multicurrency_revaluation.bank_journal_usd')
-        bank_journal_usd.currency_id = usd_currency.id
-
-        invoice_line_data = {
-            'product_id': ref('product.product_product_5').id,
-            'quantity': 1.0,
-            'account_id': revenue_acc.id,
-            'name': 'product test 5',
-            'price_unit': 800.00,
-            'currency_id': usd_currency.id
-        }
-
-        partner = ref('base.res_partner_3')
-        partner.company_id = cls.company.id
-        partner.property_account_payable_id = receivable_acc.id
-        partner.property_account_receivable_id = payable_acc.id
-
-        payment_term = ref('account.account_payment_term')
-
-        year = fields.Date.today().strftime('%Y')
-        invoice = cls.env['account.invoice'].create({
-            'name': "Customer Invoice",
-            'date_invoice': '%s-01-16' % year,
-            'currency_id': usd_currency.id,
-            'company_id': cls.company.id,
-            'journal_id': sales_journal.id,
-            'partner_id': partner.id,
-            'account_id': receivable_acc.id,
-            'invoice_line_ids': [(0, 0, invoice_line_data)],
-            'payment_term_id': payment_term.id,
-        })
-        # Validate invoice
-        invoice.action_invoice_open()
-
-        payment_method = ref(
-            'account.account_payment_method_manual_in')
-
-        # Register partial payment
-        payment = cls.env['account.payment'].create({
-            'invoice_ids': [(4, invoice.id, 0)],
-            'amount': 700,
-            'currency_id': usd_currency.id,
-            'payment_date': '%s-02-15' % year,
-            'communication': 'Invoice partial payment',
-            'partner_id': invoice.partner_id.id,
-            'partner_type': 'customer',
-            'journal_id': bank_journal_usd.id,
-            'payment_type': 'inbound',
-            'payment_method_id': payment_method.id,
-            'payment_difference_handling': 'open',
-            'writeoff_account_id': False,
-        })
-        payment.post()
-
-        # create invoice in GBP
-        gbp_currency = ref('base.GBP')
-
-        bank_journal_gbp = ref(
-            'account_multicurrency_revaluation.bank_journal_gbp')
-
-        bank_journal_gbp.currency_id = gbp_currency.id
-
-        invoice_line_data = {
-            'product_id': cls.env.ref('product.product_product_5').id,
-            'quantity': 1.0,
-            'account_id': revenue_acc.id,
-            'name': 'product test 5',
-            'price_unit': 800.00,
-            'currency_id': gbp_currency.id
-        }
-
-        invoice = cls.env['account.invoice'].create({
-            'name': "Customer Invoice",
-            'date_invoice': '%s-01-16' % year,
-            'currency_id': gbp_currency.id,
-            'journal_id': sales_journal.id,
-            'company_id': cls.company.id,
-            'partner_id': ref('base.res_partner_3').id,
-            'account_id': receivable_acc.id,
-            'invoice_line_ids': [(0, 0, invoice_line_data)],
-            'payment_term_id': payment_term.id,
-        })
-        # Validate invoice
-        invoice.action_invoice_open()
-
-        # Register partial payment
-        payment = cls.env['account.payment'].create({
-            'invoice_ids': [(4, invoice.id, 0)],
-            'amount': 700,
-            'currency_id': gbp_currency.id,
-            'payment_date': '%s-02-15' % year,
-            'communication': 'Invoice partial payment',
-            'partner_id': invoice.partner_id.id,
-            'partner_type': 'customer',
-            'journal_id': bank_journal_gbp.id,
-            'payment_type': 'inbound',
-            'payment_method_id': payment_method.id,
-            'payment_difference_handling': 'open',
-            'writeoff_account_id': False,
-        })
-        payment.post()
-
-    def test_uk_revaluation(self):
-        # Set accounts on company
-        values = {
-            'revaluation_loss_account_id':
-                self.env.ref('account_multicurrency_revaluation.'
-                             'acc_reval_loss').id,
-            'revaluation_gain_account_id':
-                self.env.ref('account_multicurrency_revaluation.'
-                             'acc_reval_gain').id,
-            'currency_reval_journal_id': self.reval_journal.id,
-        }
-        self.company.write(values)
-        self.assertEqual(self.company.currency_id, self.env.ref('base.EUR'))
-
-        wizard = self.env['wizard.currency.revaluation']
-        data = {
-            'revaluation_date': '%s-03-15' % fields.Date.today().strftime(
-                '%Y'),
-            'journal_id': self.reval_journal.id,
-            'label': '[%(account)s,%(rate)s] wiz_test',
-        }
-        wiz = wizard.create(data)
-        result = wiz.revaluate_currency()
-
-        # Assert the wizard show the created revaluation lines
-        self.assertEqual(result.get('name'), "Created revaluation lines")
-
-        reval_move_lines = self.env['account.move.line'].search([
-            ('name', 'like', 'wiz_test')])
-
-        # Assert 8 account.move.line were generated
-        self.assertEqual(len(reval_move_lines), 8)
-
-        for reval_line in reval_move_lines:
-
-            label = reval_line.name
-            rate = label[label.find(',') + 1:label.find(']')].strip()
-            self.assertEqual(rate, '2.5')
-
-            if reval_line.account_id.name == 'Account Liquidity USD':
-                self.assertFalse(reval_line.partner_id)
-                self.assertEqual(reval_line.credit, 0.0)
-                self.assertEqual(reval_line.debit, 105.0)
-            elif reval_line.account_id.name == 'Account Liquidity GBP':
-                self.assertFalse(reval_line.partner_id)
-                self.assertEqual(reval_line.credit, 0.0)
-                self.assertEqual(reval_line.debit, 105.0)
-            elif reval_line.account_id.name == 'Account Receivable':
-                self.assertIsNotNone(reval_line.partner_id.id)
-                self.assertEqual(reval_line.credit, 185.0)
-                self.assertEqual(reval_line.debit, 0.0)
-            elif reval_line.account_id.name == 'Reval Gain':
-                self.assertEqual(reval_line.credit, 105.0)
-                self.assertEqual(reval_line.debit, 0.0)
-            elif reval_line.account_id.name == 'Reval Loss':
-                self.assertEqual(reval_line.credit, 0.0)
-                self.assertEqual(reval_line.debit, 185.0)
+        cls.reval_journal = cls.env.ref(
+            'account_multicurrency_revaluation.reval_journal'
+        )
 
     def test_defaults(self):
         self.env['res.config.settings'].create({
@@ -210,13 +38,12 @@ class TestCurrencyRevaluation(SavepointCase):
                              'acc_reval_gain').id
         }).execute()
 
-        wizard = self.env['wizard.currency.revaluation'].create(
-            {'journal_id': self.reval_journal.id, })
+        wizard = self.env['wizard.currency.revaluation'].create({})
 
-        self.assertEqual(wizard.revaluation_date, fields.date.today())
+        self.assertEqual(wizard.revaluation_date, fields.Date.today())
         self.assertEqual(wizard.journal_id, self.reval_journal)
 
-    def test_us_revaluation(self):
+    def test_revaluation(self):
         """Create Invoices and Run the revaluation currency wizard
         with different rates which result should be:
                                  Debit    Credit    Amount Currency
@@ -233,13 +60,13 @@ class TestCurrencyRevaluation(SavepointCase):
         """
         self.delete_journal_data()
         usd_currency = self.env.ref('base.USD')
-        dates = (fields.Date.today() - timedelta(days=30),
-                 fields.Date.today() - timedelta(days=15),
-                 fields.Date.today() - timedelta(days=7),
-                 fields.Date.today() - timedelta(days=1),
-                 )
-        rates = (4.00, 2.50, 1.00, 1.25)
-        self.create_rates(dates, rates, usd_currency)
+        rates = {
+            (self.today - timedelta(days=30)): 4.00,
+            (self.today - timedelta(days=15)): 2.50,
+            (self.today - timedelta(days=7)): 1.00,
+            (self.today - timedelta(days=1)): 1.25,
+        }
+        self.create_rates(rates, usd_currency)
         acc_reval_loss = self.env.ref('account_multicurrency_revaluation.'
                                       'acc_reval_loss')
         acc_reval_gain = self.env.ref('account_multicurrency_revaluation.'
@@ -248,6 +75,7 @@ class TestCurrencyRevaluation(SavepointCase):
             'revaluation_loss_account_id': acc_reval_loss.id,
             'revaluation_gain_account_id': acc_reval_gain.id,
             'currency_reval_journal_id': self.reval_journal.id,
+            'reversable_revaluations': False,
         }
         self.company.write(values)
         receivable_acc = self.env.ref(
@@ -255,12 +83,12 @@ class TestCurrencyRevaluation(SavepointCase):
         receivable_acc.write({'reconcile': True})
 
         invoice1 = self.create_invoice(
-            fields.Date.today() - timedelta(days=30), usd_currency, 1.0,
-            100.00)
+            self.today - timedelta(days=30), usd_currency, 1.0, 100.00
+        )
         invoice1.action_invoice_open()
         invoice2 = self.create_invoice(
-            fields.Date.today() - timedelta(days=15), usd_currency, 1.0,
-            100.00)
+            self.today - timedelta(days=15), usd_currency, 1.0, 100.00
+        )
         invoice2.action_invoice_open()
 
         reval_move_lines = self.env['account.move.line'].search([
@@ -269,7 +97,7 @@ class TestCurrencyRevaluation(SavepointCase):
         self.assertEqual(sum(reval_move_lines.mapped('amount_currency')),
                          200.00)
 
-        result = self.wizard_execute(fields.Date.today() - timedelta(days=7))
+        result = self.wizard_execute(self.today - timedelta(days=7))
         self.assertEqual(result.get('name'), "Created revaluation lines")
         reval_move_lines = self.env['account.move.line'].search([
             ('account_id', '=', receivable_acc.id)])
@@ -277,7 +105,7 @@ class TestCurrencyRevaluation(SavepointCase):
         self.assertEqual(sum(reval_move_lines.mapped('amount_currency')),
                          200.00)
 
-        result = self.wizard_execute(fields.Date.today() - timedelta(days=1))
+        result = self.wizard_execute(self.today - timedelta(days=1))
         self.assertEqual(result.get('name'), "Created revaluation lines")
         reval_move_lines = self.env['account.move.line'].search([
             ('account_id', '=', receivable_acc.id)])
@@ -319,13 +147,12 @@ class TestCurrencyRevaluation(SavepointCase):
         self.delete_journal_data()
         usd_currency = self.env.ref('base.USD')
         eur_currency = self.env.ref('base.EUR')
-        year = fields.Date.today().strftime('%Y')
-        dates = (fields.Date.to_date('%s-11-10' % year),
-                 fields.Date.to_date('%s-11-14' % year),
-                 fields.Date.to_date('%s-11-16' % year),
-                 )
-        rates = (0.75, 1.00, 1.25)
-        self.create_rates(dates, rates, eur_currency)
+        rates = {
+            (self.today - timedelta(days=90)): 0.75,
+            (self.today - timedelta(days=80)): 1.00,
+            (self.today - timedelta(days=70)): 1.25,
+        }
+        self.create_rates(rates, eur_currency)
         acc_reval_loss = self.env.ref('account_multicurrency_revaluation.'
                                       'acc_reval_loss')
         acc_reval_gain = self.env.ref('account_multicurrency_revaluation.'
@@ -334,16 +161,18 @@ class TestCurrencyRevaluation(SavepointCase):
             'revaluation_loss_account_id': acc_reval_loss.id,
             'revaluation_gain_account_id': acc_reval_gain.id,
             'currency_reval_journal_id': self.reval_journal.id,
+            'reversable_revaluations': False,
             'currency_id': usd_currency.id,
         }
         self.company.write(values)
         receivable_acc = self.env.ref(
             'account_multicurrency_revaluation.demo_acc_receivable')
 
-        invoice = self.create_invoice(fields.Date.to_date('%s-11-11' % year),
-                                      eur_currency, 5.0, 1000.00)
+        invoice = self.create_invoice(
+            self.today - timedelta(days=89), eur_currency, 5.0, 1000.00
+        )
         invoice.action_invoice_open()
-        result = self.wizard_execute(fields.Date.to_date('%s-11-16' % year))
+        result = self.wizard_execute(self.today - timedelta(days=70))
         self.assertEqual(result.get('name'), "Created revaluation lines")
         reval_move_lines = self.env['account.move.line'].search([
             ('account_id', '=', receivable_acc.id)])
@@ -367,7 +196,7 @@ class TestCurrencyRevaluation(SavepointCase):
             'invoice_ids': [(4, invoice.id, 0)],
             'amount': 4000,
             'currency_id': eur_currency.id,
-            'payment_date': '%s-11-15' % year,
+            'payment_date': self.today - timedelta(days=79),
             'communication': 'Invoice partial payment',
             'partner_id': invoice.partner_id.id,
             'partner_type': 'customer',
@@ -379,7 +208,7 @@ class TestCurrencyRevaluation(SavepointCase):
         })
         payment.post()
 
-        result = self.wizard_execute(fields.Date.to_date('%s-11-16' % year))
+        result = self.wizard_execute(self.today - timedelta(days=70))
         self.assertEqual(result.get('name'), "Created revaluation lines")
         reval_move_lines = self.env['account.move.line'].search([
             ('account_id', '=', receivable_acc.id)])
@@ -389,19 +218,402 @@ class TestCurrencyRevaluation(SavepointCase):
                          1000.00)
 
         receivable_lines = len(reval_move_lines)
-        result = self.wizard_execute(fields.Date.to_date('%s-11-16' % year))
+        with self.assertRaises(Warning):
+            self.wizard_execute(self.today - timedelta(days=70))
         reval_move_lines = self.env['account.move.line'].search([
             ('account_id', '=', receivable_acc.id)])
         self.assertEqual(len(reval_move_lines), receivable_lines)
 
-    def create_rates(self, dates, rates, currency):
-        self.env['res.currency.rate'].search([]).unlink()
-        for date, rate in zip(dates, rates):
+    def test_revaluation_bank_account(self):
+        self.delete_journal_data()
+        usd_currency = self.env.ref('base.USD')
+        eur_currency = self.env.ref('base.EUR')
+        rates = {
+            (self.today - timedelta(days=90)): 0.75,
+            (self.today - timedelta(days=80)): 1.00,
+            (self.today - timedelta(days=70)): 1.25,
+        }
+        self.create_rates(rates, eur_currency)
+        acc_reval_loss = self.env.ref('account_multicurrency_revaluation.'
+                                      'acc_reval_loss')
+        acc_reval_gain = self.env.ref('account_multicurrency_revaluation.'
+                                      'acc_reval_gain')
+        values = {
+            'revaluation_loss_account_id': acc_reval_loss.id,
+            'revaluation_gain_account_id': acc_reval_gain.id,
+            'currency_reval_journal_id': self.reval_journal.id,
+            'reversable_revaluations': False,
+            'currency_id': usd_currency.id,
+        }
+        self.company.write(values)
+
+        eur_bank = self.env['account.journal'].create({
+            'name': 'EUR Bank',
+            'type': 'bank',
+            'code': 'EURBK',
+            'currency_id': eur_currency.id,
+        })
+        eur_bank.default_debit_account_id.currency_revaluation = True
+        bank_account = eur_bank.default_debit_account_id
+
+        liability_account = self.env['account.account'].create({
+            'name': 'Liability',
+            'code': 'L',
+            'user_type_id': self.env.ref(
+                'account.data_account_type_current_liabilities'
+            ).id,
+            'company_id': self.company.id,
+        })
+
+        bank_stmt = self.env['account.bank.statement'].create({
+            'journal_id': eur_bank.id,
+            'date': self.today - timedelta(days=60),
+            'name': 'Statement',
+        })
+
+        bank_stmt_line_1 = self.env['account.bank.statement.line'].create({
+            'name': 'Incoming 100 EUR',
+            'statement_id': bank_stmt.id,
+            'amount': 100.0,
+            'date': self.today - timedelta(days=90),
+        })
+        bank_stmt_line_1.process_reconciliation(new_aml_dicts=[{
+            'credit': 100.0,
+            'debit': 0.0,
+            'name': 'Incoming 100 EUR',
+            'account_id': liability_account.id,
+        }])
+
+        bank_stmt_line_2 = self.env['account.bank.statement.line'].create({
+            'name': 'Outgoing 25 EUR',
+            'statement_id': bank_stmt.id,
+            'amount': -25.0,
+            'date': self.today - timedelta(days=79),
+        })
+        invoice = self.create_invoice(
+            self.today - timedelta(days=79),
+            eur_currency,
+            1.0,
+            25.0
+        )
+        invoice.action_invoice_open()
+        invoice_move_line = next(
+            move_line
+            for move_line in invoice.move_id.line_ids
+            if move_line.account_id == invoice.account_id
+        )
+        bank_stmt_line_2.process_reconciliation(counterpart_aml_dicts=[{
+            'move_line': invoice_move_line,
+            'credit': 0,
+            'debit': 25,
+            'name': invoice_move_line.name,
+        }])
+
+        bank_stmt_line_3 = self.env['account.bank.statement.line'].create({
+            'name': 'Incoming 50 EUR',
+            'statement_id': bank_stmt.id,
+            'amount': 50.0,
+            'date': self.today - timedelta(days=69),
+        })
+        bank_stmt_line_3.process_reconciliation(new_aml_dicts=[{
+            'credit': 50.0,
+            'debit': 0.0,
+            'name': 'Incoming 50 EUR',
+            'account_id': liability_account.id,
+        }])
+
+        bank_account_lines = self.env['account.move.line'].search([
+            ('account_id', '=', bank_account.id),
+        ])
+        self.assertEqual(len(bank_account_lines), 3)
+        self.assertEqual(sum(bank_account_lines.mapped('debit')), 173.33)
+        self.assertEqual(sum(bank_account_lines.mapped('credit')), 25.0)
+        self.assertEqual(
+            sum(bank_account_lines.mapped('amount_currency')),
+            125.0
+        )
+
+        result = self.wizard_execute(self.today - timedelta(days=60))
+        self.assertEqual(result.get('name'), "Created revaluation lines")
+
+        revaluation_line = self.env['account.move.line'].search([
+            ('account_id', '=', bank_account.id),
+        ]) - bank_account_lines
+        self.assertEqual(len(revaluation_line), 1)
+        self.assertEqual(revaluation_line.debit, 0.0)
+        self.assertEqual(revaluation_line.credit, 48.33)
+        self.assertEqual(revaluation_line.amount_currency, 0.0)
+
+        bank_account_lines |= revaluation_line
+        self.assertEqual(sum(bank_account_lines.mapped('debit')), 173.33)
+        self.assertEqual(sum(bank_account_lines.mapped('credit')), 73.33)
+        self.assertEqual(
+            sum(bank_account_lines.mapped('amount_currency')),
+            125.0
+        )
+
+    def test_revaluation_bank_account_same_currency(self):
+        self.delete_journal_data()
+        usd_currency = self.env.ref('base.USD')
+        eur_currency = self.env.ref('base.EUR')
+        rates = {
+            (self.today - timedelta(days=90)): 0.75,
+            (self.today - timedelta(days=80)): 1.00,
+            (self.today - timedelta(days=70)): 1.25,
+        }
+        self.create_rates(rates, eur_currency)
+        acc_reval_loss = self.env.ref('account_multicurrency_revaluation.'
+                                      'acc_reval_loss')
+        acc_reval_gain = self.env.ref('account_multicurrency_revaluation.'
+                                      'acc_reval_gain')
+        values = {
+            'revaluation_loss_account_id': acc_reval_loss.id,
+            'revaluation_gain_account_id': acc_reval_gain.id,
+            'currency_reval_journal_id': self.reval_journal.id,
+            'reversable_revaluations': False,
+            'currency_id': usd_currency.id,
+        }
+        self.company.write(values)
+
+        usd_bank = self.env['account.journal'].create({
+            'name': 'USD Bank',
+            'type': 'bank',
+            'code': 'USDBK',
+            'currency_id': usd_currency.id,
+        })
+        usd_bank.default_debit_account_id.currency_revaluation = True
+        bank_account = usd_bank.default_debit_account_id
+
+        liability_account = self.env['account.account'].create({
+            'name': 'Liability',
+            'code': 'L',
+            'user_type_id': self.env.ref(
+                'account.data_account_type_current_liabilities'
+            ).id,
+            'company_id': self.company.id,
+        })
+
+        bank_stmt = self.env['account.bank.statement'].create({
+            'journal_id': usd_bank.id,
+            'date': self.today - timedelta(days=60),
+            'name': 'Statement',
+        })
+
+        bank_stmt_line_1 = self.env['account.bank.statement.line'].create({
+            'name': 'Incoming 100 USD',
+            'statement_id': bank_stmt.id,
+            'amount': 100.0,
+            'date': '2020-11-10',
+        })
+        bank_stmt_line_1.process_reconciliation(new_aml_dicts=[{
+            'credit': 100.0,
+            'debit': 0.0,
+            'name': 'Incoming 100 USD',
+            'account_id': liability_account.id,
+        }])
+
+        bank_stmt_line_2 = self.env['account.bank.statement.line'].create({
+            'name': 'Outgoing 25 USD',
+            'statement_id': bank_stmt.id,
+            'amount': -25.0,
+            'date': self.today - timedelta(days=79),
+        })
+        invoice = self.create_invoice(
+            self.today - timedelta(days=79),
+            usd_currency,
+            1.0,
+            25.0
+        )
+        invoice.action_invoice_open()
+        invoice_move_line = next(
+            move_line
+            for move_line in invoice.move_id.line_ids
+            if move_line.account_id == invoice.account_id
+        )
+        bank_stmt_line_2.process_reconciliation(counterpart_aml_dicts=[{
+            'move_line': invoice_move_line,
+            'credit': 0,
+            'debit': 25,
+            'name': invoice_move_line.name,
+        }])
+
+        bank_stmt_line_3 = self.env['account.bank.statement.line'].create({
+            'name': 'Incoming 50 USD',
+            'statement_id': bank_stmt.id,
+            'amount': 50.0,
+            'date': self.today - timedelta(days=69),
+            'amount_currency': 50.0,
+        })
+        bank_stmt_line_3.process_reconciliation(new_aml_dicts=[{
+            'credit': 50.0,
+            'debit': 0.0,
+            'name': 'Incoming 50 USD',
+            'account_id': liability_account.id,
+        }])
+
+        bank_stmt_line_4 = self.env['account.bank.statement.line'].create({
+            'name': 'Incoming 50 EUR',
+            'statement_id': bank_stmt.id,
+            'amount': 62.5,
+            'date': self.today - timedelta(days=69),
+            'amount_currency': 50.0,
+            'currency_id': eur_currency.id,
+        })
+        bank_stmt_line_4.process_reconciliation(new_aml_dicts=[{
+            'credit': 50,
+            'debit': 0.0,
+            'name': 'Incoming 50 EUR',
+            'account_id': liability_account.id,
+        }])
+
+        bank_account_lines = self.env['account.move.line'].search([
+            ('account_id', '=', bank_account.id),
+        ])
+        self.assertEqual(len(bank_account_lines), 4)
+        self.assertEqual(sum(bank_account_lines.mapped('debit')), 212.5)
+        self.assertEqual(sum(bank_account_lines.mapped('credit')), 25.0)
+
+        with self.assertRaises(Warning):
+            self.wizard_execute(self.today - timedelta(days=60))
+
+        self.assertEqual(
+            bank_account_lines,
+            self.env['account.move.line'].search([
+                ('account_id', '=', bank_account.id),
+            ])
+        )
+
+    def test_revaluation_reverse(self):
+        self.delete_journal_data()
+        usd_currency = self.env.ref('base.USD')
+        eur_currency = self.env.ref('base.EUR')
+        rates = {
+            (self.today - timedelta(days=90)): 0.75,
+            (self.today - timedelta(days=80)): 1.00,
+            (self.today - timedelta(days=70)): 1.25,
+        }
+        self.create_rates(rates, eur_currency)
+        acc_reval_loss = self.env.ref('account_multicurrency_revaluation.'
+                                      'acc_reval_loss')
+        acc_reval_gain = self.env.ref('account_multicurrency_revaluation.'
+                                      'acc_reval_gain')
+        values = {
+            'revaluation_loss_account_id': acc_reval_loss.id,
+            'revaluation_gain_account_id': acc_reval_gain.id,
+            'currency_reval_journal_id': self.reval_journal.id,
+            'reversable_revaluations': True,
+            'currency_id': usd_currency.id,
+        }
+        self.company.write(values)
+
+        eur_bank = self.env['account.journal'].create({
+            'name': 'EUR Bank',
+            'type': 'bank',
+            'code': 'EURBK',
+            'currency_id': eur_currency.id,
+        })
+        eur_bank.default_debit_account_id.currency_revaluation = True
+        bank_account = eur_bank.default_debit_account_id
+
+        liability_account = self.env['account.account'].create({
+            'name': 'Liability',
+            'code': 'L',
+            'user_type_id': self.env.ref(
+                'account.data_account_type_current_liabilities'
+            ).id,
+            'company_id': self.company.id,
+        })
+
+        bank_stmt = self.env['account.bank.statement'].create({
+            'journal_id': eur_bank.id,
+            'date': self.today - timedelta(days=60),
+            'name': 'Statement',
+        })
+
+        bank_stmt_line_1 = self.env['account.bank.statement.line'].create({
+            'name': 'Incoming 100 EUR',
+            'statement_id': bank_stmt.id,
+            'amount': 100.0,
+            'date': self.today - timedelta(days=90),
+        })
+        bank_stmt_line_1.process_reconciliation(new_aml_dicts=[{
+            'credit': 100.0,
+            'debit': 0.0,
+            'name': 'Incoming 100 EUR',
+            'account_id': liability_account.id,
+        }])
+
+        bank_stmt_line_2 = self.env['account.bank.statement.line'].create({
+            'name': 'Outgoing 25 EUR',
+            'statement_id': bank_stmt.id,
+            'amount': -25.0,
+            'date': self.today - timedelta(days=79),
+        })
+        invoice = self.create_invoice(
+            self.today - timedelta(days=79),
+            eur_currency,
+            1.0,
+            25.0
+        )
+        invoice.action_invoice_open()
+        invoice_move_line = next(
+            move_line
+            for move_line in invoice.move_id.line_ids
+            if move_line.account_id == invoice.account_id
+        )
+        bank_stmt_line_2.process_reconciliation(counterpart_aml_dicts=[{
+            'move_line': invoice_move_line,
+            'credit': 0,
+            'debit': 25,
+            'name': invoice_move_line.name,
+        }])
+
+        bank_stmt_line_3 = self.env['account.bank.statement.line'].create({
+            'name': 'Incoming 50 EUR',
+            'statement_id': bank_stmt.id,
+            'amount': 50.0,
+            'date': self.today - timedelta(days=69),
+        })
+        bank_stmt_line_3.process_reconciliation(new_aml_dicts=[{
+            'credit': 50.0,
+            'debit': 0.0,
+            'name': 'Incoming 50 EUR',
+            'account_id': liability_account.id,
+        }])
+
+        bank_account_lines = self.env['account.move.line'].search([
+            ('account_id', '=', bank_account.id),
+        ])
+        self.assertEqual(len(bank_account_lines), 3)
+        self.assertEqual(sum(bank_account_lines.mapped('debit')), 173.33)
+        self.assertEqual(sum(bank_account_lines.mapped('credit')), 25.0)
+        self.assertEqual(
+            sum(bank_account_lines.mapped('amount_currency')),
+            125.0
+        )
+
+        result = self.wizard_execute(self.today - timedelta(days=60))
+        self.assertEqual(result.get('name'), "Created revaluation lines")
+
+        revaluation_lines = self.env['account.move.line'].search([
+            ('account_id', '=', bank_account.id),
+        ]) - bank_account_lines
+        self.assertEqual(len(revaluation_lines), 2)
+        self.assertEqual(sum(revaluation_lines.mapped('debit')), 48.33)
+        self.assertEqual(sum(revaluation_lines.mapped('credit')), 48.33)
+        self.assertEqual(sum(revaluation_lines.mapped('amount_currency')), 0.0)
+
+    def create_rates(self, rates_by_date, currency, purge=True):
+        unlink_domain = []
+        if not purge:
+            unlink_domain += [('currency_id', '=', currency.id)]
+        self.env['res.currency.rate'].search(unlink_domain).unlink()
+        for date, rate in rates_by_date.items():
             self.env['res.currency.rate'].create({
                 'currency_id': currency.id,
                 'company_id': self.company.id,
                 'name': date,
-                'rate': rate
+                'rate': rate,
             })
 
     def create_invoice(self, date, currency, quantity, price):
@@ -439,12 +651,11 @@ class TestCurrencyRevaluation(SavepointCase):
         return invoice
 
     def wizard_execute(self, date):
-        data = {
+        wiz = self.env['wizard.currency.revaluation'].create({
             'revaluation_date': date,
             'journal_id': self.reval_journal.id,
             'label': '[%(account)s] [%(currency)s] wiz_test',
-        }
-        wiz = self.env['wizard.currency.revaluation'].create(data)
+        })
         return wiz.revaluate_currency()
 
     def delete_journal_data(self):

--- a/account_multicurrency_revaluation/wizard/print_currency_unrealized_report.py
+++ b/account_multicurrency_revaluation/wizard/print_currency_unrealized_report.py
@@ -1,4 +1,5 @@
 # Copyright 2012-2018 Camptocamp SA
+# Copyright 2020 CorporateHub (https://corporatehub.eu)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 
@@ -13,7 +14,7 @@ class UnrealizedCurrencyReportPrinter(models.TransientModel):
     account_ids = fields.Many2many(
         'account.account',
         string='Accounts',
-        domain="[('currency_revaluation', '=', True)]",
+        domain=[('currency_revaluation', '=', True)],
         default=lambda self: self._default_account_ids(),
     )
 

--- a/account_multicurrency_revaluation/wizard/wizard_currency_revaluation_view.xml
+++ b/account_multicurrency_revaluation/wizard/wizard_currency_revaluation_view.xml
@@ -21,7 +21,8 @@
                 </group>
                 <group>
                     <label for="" string="%%(currency)s : Currency to be revaluated"/>
-                    <label for="" string="%%(account)s : Account for which the revaluation is applied"/>
+                    <label for="" string="%%(account)s : Account code for which the revaluation is applied"/>
+                    <label for="" string="%%(account_name)s : Account name for which the revaluation is applied"/>
                     <label for="" string="%%(rate)s : Value of rate applied during revaluation"/>
                 </group>
                 <footer>

--- a/account_multicurrency_revaluation_rate_type/readme/CONTRIBUTORS.rst
+++ b/account_multicurrency_revaluation_rate_type/readme/CONTRIBUTORS.rst
@@ -1,2 +1,5 @@
 * Frederic Clementi <frederic.clementi@camptocamp.com>
 * Iryna Vyshnevska <i.vyshnevska@mobilunity.com>
+* `CorporateHub <https://corporatehub.eu/>`__
+
+  * Alexey Pelykh <alexey.pelykh@corphub.eu>

--- a/account_multicurrency_revaluation_rate_type/tests/test_currency_revaluation.py
+++ b/account_multicurrency_revaluation_rate_type/tests/test_currency_revaluation.py
@@ -1,9 +1,8 @@
-# -*- coding: utf-8 -*-
 # Copyright 2019 Camptocamp SA
+# Copyright 2020 CorporateHub (https://corporatehub.eu)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from datetime import date
-from odoo.tools.safe_eval import safe_eval
 from odoo.tests.common import SavepointCase
 
 
@@ -155,8 +154,7 @@ class TestCurrencyRevaluationType(SavepointCase):
         self.assertAlmostEqual(sum(debit.mapped('balance')), -266.67)
 
     def _get_move_ids(self, result):
-        return self.env['account.move.line']. \
-            browse(safe_eval(result['domain'])[0][2])
+        return self.env['account.move.line'].browse(result['domain'][0][2])
 
     def wizard_execute(self, date, currency_type):
 

--- a/account_multicurrency_revaluation_rate_type/wizard/wizard_currency_revaluation.py
+++ b/account_multicurrency_revaluation_rate_type/wizard/wizard_currency_revaluation.py
@@ -1,4 +1,5 @@
 # Copyright 2019 Camptocamp SA
+# Copyright 2020 CorporateHub (https://corporatehub.eu)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import models, fields, api
@@ -25,7 +26,7 @@ class WizardCurrencyRevaluationType(models.TransientModel):
     )
 
     @api.model
-    def _compute_unrealized_currency_gl(self, currency_id, balances):
+    def _compute_unrealized_currency_gl(self, currency, balances):
         if self.revaluation_rate_type == 'monthly':
-            self = self.with_context(monthly_rate=True)
-        return super()._compute_unrealized_currency_gl(currency_id, balances)
+            currency = currency.with_context(monthly_rate=True)
+        return super()._compute_unrealized_currency_gl(currency, balances)


### PR DESCRIPTION
Things done:
 * [FIX] #126, #117: bank account revaluations are not grouped by partner
 * [FIX] Bank account revaluations are not performed if currency of account matches company currency
 * [IMP] When revaluation is performed in the past, force-execute reversal (if needed)
 * [IMP] Exchange rate is rounded during representation in same way as Odoo does
 * [IMP] Float comparison operations take currency rounding into account
 * [FIX] README cleanup