### PR TITLE
[13.0][FIX]account_cutoff_base: fix migration to version 13.0

### DIFF
--- a/account_cutoff_base/migrations/13.0.1.0.0/noupdate_changes.xml
+++ b/account_cutoff_base/migrations/13.0.1.0.0/noupdate_changes.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+    <record id="account_cutoff_multi_company_rule" model="ir.rule">
+        <field
+            name="domain_force"
+        >['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+    </record>
+    <record id="account_cutoff_mapping_multi_company_rule" model="ir.rule">
+        <field
+            name="domain_force"
+        >['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+    </record>
+</odoo>

--- a/account_cutoff_base/migrations/13.0.1.0.0/post-migration.py
+++ b/account_cutoff_base/migrations/13.0.1.0.0/post-migration.py
@@ -1,0 +1,11 @@
+# Copyright 2021 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade  # pylint: disable=W7936
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.load_data(
+        env.cr, "account_cutoff_base", "migrations/13.0.1.0.0/noupdate_changes.xml"
+    )

--- a/account_cutoff_base/models/account_cutoff.py
+++ b/account_cutoff_base/models/account_cutoff.py
@@ -64,11 +64,11 @@ class AccountCutoff(models.Model):
 
     @api.model
     def _default_cutoff_journal_id(self):
-        return self.env.user.company_id.default_cutoff_journal_id
+        return self.env.company.default_cutoff_journal_id
 
     @api.model
     def _default_move_partner(self):
-        return self.env.user.company_id.default_cutoff_move_partner
+        return self.env.company.default_cutoff_move_partner
 
     cutoff_date = fields.Date(
         string="Cut-off Date",


### PR DESCRIPTION
This PR adds a couple of fixes to the migration of the module to version 13:

- Add migration script for the multi-company rules, as they were changed in the migration.
- Use the active company (instead of the user company) when selecting the default account and journal in cutoff.