### PR TITLE
[12.0][IMP] closing type not null

### DIFF
--- a/account_fiscal_year_closing/__manifest__.py
+++ b/account_fiscal_year_closing/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Fiscal year closing",
     "summary": "Generic fiscal year closing wizard",
-    "version": "12.0.1.1.1",
+    "version": "12.0.1.2.0",
     "category": "Accounting & Finance",
     "website": "https://github.com/OCA/account-closing",
     "author": "Tecnativa, "

--- a/account_fiscal_year_closing/migrations/12.0.1.2.0/pre-migration.py
+++ b/account_fiscal_year_closing/migrations/12.0.1.2.0/pre-migration.py
@@ -1,0 +1,13 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.logged_query(
+        env.cr, """
+            UPDATE account_move
+                SET closing_type = 'none'
+            WHERE closing_type is null;
+            """
+    )

--- a/account_fiscal_year_closing/models/account_move.py
+++ b/account_fiscal_year_closing/models/account_move.py
@@ -26,5 +26,6 @@ class AccountMove(models.Model):
     )
     closing_type = fields.Selection(
         selection=_selection_closing_type, default="none",
+        required=True,
         states={'posted': [('readonly', True)]},
     )


### PR DESCRIPTION
By default `closing_type` is `'none'` but user can manually set null. Having a null value is bad for reporting, so this PR will remove this possibility.