### PR TITLE
[FIX] account_cutoff_base: add pre-migrate script to rename fields changed in migration to 11.0

### DIFF
--- a/account_cutoff_base/migrations/11.0.1.0.0/pre-migrate.py
+++ b/account_cutoff_base/migrations/11.0.1.0.0/pre-migrate.py
@@ -1,0 +1,15 @@
+# Copyright 2021 Alex Comba - Agile Business Group
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+_field_renames = [
+    ("account.cutoff", "account_cutoff", "type", "cutoff_type"),
+]
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if not version:
+        return
+    openupgrade.rename_fields(env, _field_renames)

--- a/account_cutoff_base/readme/CONTRIBUTORS.rst
+++ b/account_cutoff_base/readme/CONTRIBUTORS.rst
@@ -5,3 +5,4 @@
 * Pedro M. Baeza <pedro.baeza@gmail.com>
 * Jeroen Evens <jeroen.evenss@dynapps.be>
 * Jim Hoefnagels <jim.hoefnagels@dynapps.be>
+* Alex Comba <alex.comba@agilebg.com>


### PR DESCRIPTION
See https://github.com/OCA/account-closing/commit/8267782b3ebaeee8fd102b0214e41c9b323a1554#diff-a30853050e1420bf74baaaba68936d3e32217851cc7aa701d50053ce3af9ee58L53-R65