### PR TITLE
[10.0][FIX] account_fiscal_year_closing: Consider balance of every partner

### DIFF
--- a/account_fiscal_year_closing/models/account_fiscalyear_closing.py
+++ b/account_fiscal_year_closing/models/account_fiscalyear_closing.py
@@ -488,11 +488,13 @@ class AccountFiscalyearClosingConfig(models.Model):
                 elif closing_type == 'unreconciled':
                     # Get credit and debit grouping by partner
                     partners = account_map.account_partners_get(account)
+                    balance = 0
                     for partner in partners:
-                        balance, move_line = account_map.\
+                        partner_balance, move_line = account_map.\
                             move_line_partner_prepare(account, partner)
                         if move_line:
                             move_lines.append(move_line)
+                            balance += partner_balance
                 else:
                     # Account type has unsupported closing method
                     continue

--- a/account_fiscal_year_closing/models/account_fiscalyear_closing.py
+++ b/account_fiscal_year_closing/models/account_fiscalyear_closing.py
@@ -227,8 +227,8 @@ class AccountFiscalyearClosing(models.Model):
     def _onchange_year(self):
         self.date_end = '%s-%s-%s' % (
             self.year,
-            str(self.company_id.fiscalyear_last_month).zfill(2) or '12',
-            str(self.company_id.fiscalyear_last_day).zfill(2) or '31',
+            str(self.company_id.fiscalyear_last_month or 12).zfill(2),
+            str(self.company_id.fiscalyear_last_day or 31).zfill(2),
         )
         date_end = fields.Date.from_string(self.date_end)
         self.date_start = fields.Date.to_string(

--- a/account_fiscal_year_closing/tests/__init__.py
+++ b/account_fiscal_year_closing/tests/__init__.py
@@ -1,0 +1,4 @@
+#  -*- coding: utf-8 -*-
+#  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import test_fiscal_year_closing

--- a/account_fiscal_year_closing/tests/test_fiscal_year_closing.py
+++ b/account_fiscal_year_closing/tests/test_fiscal_year_closing.py
@@ -1,0 +1,95 @@
+#  -*- coding: utf-8 -*-
+#  Copyright 2021 Simone Rubino - Agile Business Group
+#  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import datetime
+
+from odoo.addons.account.tests.account_test_classes import AccountingTestCase
+
+
+class TestFiscalYearClosing (AccountingTestCase):
+
+    def setUp(self):
+        super(TestFiscalYearClosing, self).setUp()
+        account_model = self.env['account.account']
+        self.invoice_model = self.env['account.invoice']
+        partner_model = self.env['res.partner']
+
+        self.receivable_account = account_model.create({
+            'name': 'Test closing receivable account',
+            'code': 'TCRECA',
+            'reconcile': True,
+            'user_type_id': self.ref('account.data_account_type_receivable'),
+        })
+        self.revenue_account = account_model.create({
+            'name': 'Test closing revenue account',
+            'code': 'TCREVA',
+            'reconcile': True,
+            'user_type_id': self.ref('account.data_account_type_revenue'),
+        })
+        self.dest_account = account_model.create({
+            'name': 'Test destination account',
+            'code': 'TDESTA',
+            'reconcile': True,
+            'user_type_id': self.ref('account.data_account_type_revenue'),
+        })
+        partner1_id = partner_model.name_create("Test partner 1")[0]
+        self.partner1 = partner_model.browse(partner1_id)
+        partner2_id = partner_model.name_create("Test partner 2")[0]
+        self.partner2 = partner_model.browse(partner2_id)
+
+    def _create_invoice(self, partner, today):
+        invoice = self.invoice_model.create({
+            'name': "Test invoice 1",
+            'date': today,
+            'partner_id': partner.id,
+            'account_id': self.receivable_account.id,
+            'invoice_line_ids': [(0, 0, {
+                'product_id': self.ref('product.product_product_5'),
+                'quantity': 10.0,
+                'account_id': self.revenue_account.id,
+                'name': 'product test 5',
+                'price_unit': 100.00,
+            })]
+        })
+        invoice.action_invoice_open()
+        return invoice
+
+    def test_partner_unreconcile_balance(self):
+        """
+        Check that the balance of every involved partner
+        is taken into account for destination move.
+        """
+        today = datetime.date(2021, 1, 1)
+        self._create_invoice(self.partner1, today)
+        self._create_invoice(self.partner2, today)
+        chart_id = self.ref('l10n_generic_coa.configurable_chart_template')
+        config = self.env['account.fiscalyear.closing.template'].create({
+            'name': "Test fiscal year closing",
+            'chart_template_ids': [(4, chart_id)],
+            'check_draft_moves': False,
+            'move_config_ids': [(0, 0, {
+                'name': "Test move configuration 1",
+                'code': 'TMC1',
+                'mapping_ids': [(0, 0, {
+                    'name': "All accounts to destination",
+                    'src_accounts': '%',
+                    'dest_account': self.dest_account.code,
+                })],
+                'closing_type_ids': [(0, 0, {
+                    'account_type_id': self.receivable_account.user_type_id.id,
+                    'closing_type': 'unreconciled',
+                })]
+            })],
+        })
+        closing_model = self.env['account.fiscalyear.closing']
+        closing = closing_model.new({
+            'year': today.year,
+            'closing_template_id': config.id,
+        })
+        closing._onchange_year()
+        closing_vals = closing._convert_to_write(closing._cache)
+        closing = closing_model.create(closing_vals)
+        closing.action_load_template()
+        closing.button_calculate()
+
+        self.assertEqual(closing.state, 'calculated')


### PR DESCRIPTION
**Steps**

1. Be in group "Accounting & Finance / Adviser"
2. Create a new account with a **code**
2. In Invoicing > Configuration > Fiscal Year Closing > Closing templates, create a closing template with one line
3. The line has one Account mapping:
    - Source accounts = %
    - Destination account = **code**
4. The line also has one Account closing type:
    - Account type = Receivable
    - Default closing type = Un-reconciled
5. Create and post 2 invoices for 2 different partners
2. In Invoicing > Adviser > Fiscal year closings, create a new closing for current year
3. Load the created template
4. Calculate

**Before this PR**
Popup showing an unbalanced move

**After this PR**
Create the closing moves

---

There is also another commit for a tiny bug

**Steps**
1. Be in group "Accounting & Finance / Adviser"
1. Enable multi-company
2. In Invoicing > Adviser > Fiscal year closings, create a new closing and empty the company field
3. Change the field "Year"

**Before this PR**
Error:
```
ValueError: time data '2020-False' does not match format '%Y-%m-%d'
```

**After this PR**
Dates are updated according to value of field "Year"
