### PR TITLE
[13.0][IMP]account_invoice_start_end_dates: removed required on views

### DIFF
--- a/account_invoice_start_end_dates/models/account_move_line.py
+++ b/account_invoice_start_end_dates/models/account_move_line.py
@@ -10,7 +10,6 @@ class AccountMoveLine(models.Model):
 
     start_date = fields.Date(index=True)
     end_date = fields.Date(index=True)
-    must_have_dates = fields.Boolean(related="product_id.must_have_dates")
 
     @api.constrains("start_date", "end_date")
     def _check_start_end_dates(self):

--- a/account_invoice_start_end_dates/views/account_move.xml
+++ b/account_invoice_start_end_dates/views/account_move.xml
@@ -10,15 +10,8 @@
         <field name="inherit_id" ref="account.view_move_line_form" />
         <field name="arch" type="xml">
             <field name="date_maturity" position="after">
-                <field name="must_have_dates" invisible="1" />
-                <field
-                    name="start_date"
-                    attrs="{'required': [('must_have_dates', '=', True)]}"
-                />
-                <field
-                    name="end_date"
-                    attrs="{'required': [('must_have_dates', '=', True)]}"
-                />
+                <field name="start_date" />
+                <field name="end_date" />
             </field>
         </field>
     </record>
@@ -31,29 +24,15 @@
                 expr="//field[@name='invoice_line_ids']/tree/field[@name='quantity']"
                 position="before"
             >
-                <field name="must_have_dates" invisible="1" />
-                <field
-                    name="start_date"
-                    attrs="{'required': [('must_have_dates', '=', True)]}"
-                />
-                <field
-                    name="end_date"
-                    attrs="{'required': [('must_have_dates', '=', True)]}"
-                />
+                <field name="start_date" />
+                <field name="end_date" />
             </xpath>
             <xpath
                 expr="//field[@name='invoice_line_ids']/form//field[@name='analytic_tag_ids']"
                 position="before"
             >
-                <field name="must_have_dates" invisible="1" />
-                <field
-                    name="start_date"
-                    attrs="{'required': [('must_have_dates', '=', True)]}"
-                />
-                <field
-                    name="end_date"
-                    attrs="{'required': [('must_have_dates', '=', True)]}"
-                />
+                <field name="start_date" />
+                <field name="end_date" />
             </xpath>
             <xpath
                 expr="//field[@name='line_ids']/tree/field[@name='credit']"


### PR DESCRIPTION
Removed the required on the view if the product had "must_have_dates" as it was deleting the account_move_lines (of products with mandatory start and end dates).
Now you can save the invoice but if you try to post it it's when a warning will appear to fill those mandatory fields (only if the product requires so) and won't post the invoice.
@JordiMForgeFlow @forgeflow 