### PR TITLE
[WIP][FIX] Invoice state must be posted

### DIFF
--- a/account_cutoff_accrual_picking/models/account_cutoff.py
+++ b/account_cutoff_accrual_picking/models/account_cutoff.py
@@ -98,7 +98,9 @@ class AccountCutoff(models.Model):
         product = order_line.product_id
         product_uom = product.uom_id
         moves = order_line.move_ids
-        ilines = order_line.invoice_lines
+        ilines = order_line.invoice_lines.filtered(
+            lambda r: r.move_id.state == "posted"
+        )
         oline_dict[order_line] = {
             "precut_delivered_qty": 0.0,  # in product_uom
             "precut_invoiced_qty": 0.0,  # in product_uom


### PR DESCRIPTION
# How to reproduce
## use case 1
Start to create an invoice in draft but because of lacking information or dispute with the supplier, let the invoice in draft state. This invoice shouldn't be taken in the cutoff.
## use case 2
Create a reception, create the invoice, confirm the invoice and than the reception team inform you that a back-order is just received. the change on the invoice is too major to do it manually so you cancel the invoice and you re-invoice the all purchase order. Only the last invoice must be used for the cutoff (not the canceled invoice)
# Fix proposition
To fix it, I propose to add a filtered on the invoice line (move_id.state == posted)

