### PR TITLE
[15.0][FIX] account_multicurrency_revaluation: remove redundant default

### DIFF
--- a/account_multicurrency_revaluation/model/res_config.py
+++ b/account_multicurrency_revaluation/model/res_config.py
@@ -73,5 +73,4 @@ class AccountConfigSettings(models.TransientModel):
         related="company_id.reversable_revaluations",
         string="Reversable Revaluations",
         help="Revaluations entries will be created " 'as "To Be Reversed".',
-        default=True,
     )


### PR DESCRIPTION
Avoid spamming warnings:
![Selection_533](https://user-images.githubusercontent.com/25005517/189866492-87c04626-f727-4c82-9ed2-21700569738a.png)
