### PR TITLE
[14.0] cutoff: add option to filter source move on state

### DIFF
--- a/account_cutoff_accrual_subscription/models/account_cutoff.py
+++ b/account_cutoff_accrual_subscription/models/account_cutoff.py
@@ -59,15 +59,19 @@ class AccountCutoff(models.Model):
         }
         company_currency = self.company_currency_id
         prec = company_currency.rounding
+        common_domain = [("journal_id", "in", self.source_journal_ids.ids)]
+        if self.source_move_state == "posted":
+            common_domain.append(("parent_state", "=", "posted"))
+        else:
+            common_domain.append(("parent_state", "in", ("draft", "posted")))
         work = {}
         # Generate time intervals and compute existing expenses/revenue
         for sub in subs:
             months = periodicity2months[sub.periodicity]
             work[sub] = {"intervals": [], "sub": sub}
             end_date = self.cutoff_date
-            domain_base = [
+            domain_base = common_domain + [
                 ("company_id", "=", sub.company_id.id),
-                ("journal_id", "in", self.source_journal_ids.ids),
                 ("account_id", "=", sub.account_id.id),
                 ("analytic_account_id", "=", sub.analytic_account_id.id or False),
             ]

--- a/account_cutoff_accrual_subscription/models/account_cutoff.py
+++ b/account_cutoff_accrual_subscription/models/account_cutoff.py
@@ -4,10 +4,9 @@
 
 from dateutil.relativedelta import relativedelta
 
-from odoo import _, fields, models
+from odoo import _, models
 from odoo.exceptions import UserError
-from odoo.tools import float_compare, float_is_zero, float_round
-from odoo.tools.misc import formatLang
+from odoo.tools.misc import format_amount, format_date
 
 
 class AccountCutoff(models.Model):
@@ -17,7 +16,6 @@ class AccountCutoff(models.Model):
         res = super().get_lines()
         if self.cutoff_type not in ["accrued_expense", "accrued_revenue"]:
             return res
-        aml_obj = self.env["account.move.line"]
         line_obj = self.env["account.cutoff.line"]
         sub_obj = self.env["account.cutoff.accrual.subscription"]
         type2subtype = {
@@ -44,21 +42,13 @@ class AccountCutoff(models.Model):
                         "The cutoffs with subscription only work when the cutoff "
                         "date (%s) is the last day of a month."
                     )
-                    % self.cutoff_date
+                    % format_date(self.env, self.cutoff_date)
                 )
             if not self.source_journal_ids:
                 raise UserError(_("Missing source journals."))
             self.message_post(
                 body=_("Computing provisions from %d subscriptions.") % len(subs)
             )
-        periodicity2months = {
-            "month": 1,
-            "quarter": 3,
-            "semester": 6,
-            "year": 12,
-        }
-        company_currency = self.company_currency_id
-        prec = company_currency.rounding
         common_domain = [("journal_id", "in", self.source_journal_ids.ids)]
         if self.source_move_state == "posted":
             common_domain.append(("parent_state", "=", "posted"))
@@ -67,113 +57,7 @@ class AccountCutoff(models.Model):
         work = {}
         # Generate time intervals and compute existing expenses/revenue
         for sub in subs:
-            months = periodicity2months[sub.periodicity]
-            work[sub] = {"intervals": [], "sub": sub}
-            end_date = self.cutoff_date
-            domain_base = common_domain + [
-                ("company_id", "=", sub.company_id.id),
-                ("account_id", "=", sub.account_id.id),
-                ("analytic_account_id", "=", sub.analytic_account_id.id or False),
-            ]
-            if sub.partner_type == "one":
-                if sub.partner_id:
-                    domain_base.append(("partner_id", "=", sub.partner_id.id))
-                else:
-                    raise UserError(
-                        _("Missing supplier on subscription '%s'.") % sub.display_name
-                    )
-            elif sub.partner_type == "none":
-                domain_base.append(("partner_id", "=", False))
-            domain_base_w_start_end = domain_base + [
-                ("start_date", "!=", False),
-                ("end_date", "!=", False),
-            ]
-
-            for _i in range(int(12 / months)):
-                start_date = end_date + relativedelta(day=1, months=-(months - 1))
-                if start_date < sub.start_date:
-                    break
-                # compute amount
-                amount = 0
-                # 1. No start/end dates
-                no_start_end_res = aml_obj.read_group(
-                    domain_base
-                    + [
-                        ("date", "<=", fields.Date.to_string(end_date)),
-                        ("date", ">=", fields.Date.to_string(start_date)),
-                        ("start_date", "=", False),
-                        ("end_date", "=", False),
-                    ],
-                    ["balance"],
-                    [],
-                )
-                amount_no_start_end = (
-                    no_start_end_res and no_start_end_res[0]["balance"] or 0
-                )
-                amount += amount_no_start_end * sign
-                # 2. Start/end dates, INSIDE interval
-                inside_res = aml_obj.read_group(
-                    domain_base_w_start_end
-                    + [
-                        ("start_date", ">=", start_date),
-                        ("end_date", "<=", end_date),
-                    ],
-                    ["balance"],
-                    [],
-                )
-                amount_inside = inside_res and inside_res[0]["balance"] or 0
-                amount += amount_inside * sign
-                # 3. Start/end dates, OVER interval
-                mlines = aml_obj.search(
-                    domain_base_w_start_end
-                    + [
-                        ("start_date", "<", start_date),
-                        ("end_date", ">", end_date),
-                    ]
-                )
-                for mline in mlines:
-                    total_days = (mline.end_date - mline.start_date).days + 1
-                    days_in_interval = (end_date - start_date).days + 1
-                    amount_in_interval = mline.balance * days_in_interval / total_days
-                    amount += amount_in_interval * sign
-                # 4. Start/end dates, start_date before, end_date inside
-                mlines = aml_obj.search(
-                    domain_base_w_start_end
-                    + [
-                        ("start_date", "<", start_date),
-                        ("end_date", ">=", start_date),
-                        ("end_date", "<=", end_date),
-                    ]
-                )
-                for mline in mlines:
-                    total_days = (mline.end_date - mline.start_date).days + 1
-                    days_in_interval = (mline.end_date - start_date).days + 1
-                    amount_in_interval = mline.balance * days_in_interval / total_days
-                    amount += amount_in_interval * sign
-                # 5. Start/end dates, start_date inside, end_date after
-                mlines = aml_obj.search(
-                    domain_base_w_start_end
-                    + [
-                        ("start_date", ">=", start_date),
-                        ("start_date", "<=", end_date),
-                        ("end_date", ">", end_date),
-                    ]
-                )
-                for mline in mlines:
-                    total_days = (mline.end_date - mline.start_date).days + 1
-                    days_in_interval = (end_date - mline.start_date).days + 1
-                    amount_in_interval = mline.balance * days_in_interval / total_days
-                    amount += amount_in_interval * sign
-
-                work[sub]["intervals"].append(
-                    {
-                        "start": start_date,
-                        "end": end_date,
-                        "amount": float_round(amount, precision_rounding=prec),
-                    }
-                )
-                # prepare next interval
-                end_date = start_date + relativedelta(days=-1)
+            sub._process_subscription(work, self.cutoff_date, common_domain, sign)
         # Create mapping dict
         mapping = self._get_mapping_dict()
         sub_type_label = sub_type == "expense" and _("Expense") or _("Revenue")
@@ -192,17 +76,11 @@ class AccountCutoff(models.Model):
         # Write the details of the computation in the notes
         # (or in the chatter if the amount to provision is 0)
         sub = data["sub"]
-        company_currency = self.company_currency_id
-        prec = company_currency.rounding
+        ccur = self.company_currency_id
         notes = []
         cutoff_amount = 0
         for interval in data["intervals"]:
-            if (
-                float_compare(
-                    interval["amount"], sub.min_amount, precision_rounding=prec
-                )
-                < 0
-            ):
+            if ccur.compare_amounts(interval["amount"], sub.min_amount) < 0:
                 period_cutoff_amount = self.company_currency_id.round(
                     sub.provision_amount - interval["amount"]
                 )
@@ -213,29 +91,13 @@ class AccountCutoff(models.Model):
                         "=> provisionning %s."
                     )
                     % (
-                        fields.Date.to_string(interval["start"]),
-                        fields.Date.to_string(interval["end"]),
+                        format_date(self.env, interval["start"]),
+                        format_date(self.env, interval["end"]),
                         sub_type_label,
-                        formatLang(
-                            self.env,
-                            interval["amount"],
-                            currency_obj=self.company_currency_id,
-                        ),
-                        formatLang(
-                            self.env,
-                            sub.min_amount,
-                            currency_obj=self.company_currency_id,
-                        ),
-                        formatLang(
-                            self.env,
-                            sub.provision_amount,
-                            currency_obj=self.company_currency_id,
-                        ),
-                        formatLang(
-                            self.env,
-                            period_cutoff_amount,
-                            currency_obj=self.company_currency_id,
-                        ),
+                        format_amount(self.env, interval["amount"], ccur),
+                        format_amount(self.env, sub.min_amount, ccur),
+                        format_amount(self.env, sub.provision_amount, ccur),
+                        format_amount(self.env, period_cutoff_amount, ccur),
                     )
                 )
                 cutoff_amount += period_cutoff_amount * lsign
@@ -246,22 +108,14 @@ class AccountCutoff(models.Model):
                         "amount %s => no provisionning."
                     )
                     % (
-                        fields.Date.to_string(interval["start"]),
-                        fields.Date.to_string(interval["end"]),
+                        format_date(self.env, interval["start"]),
+                        format_date(self.env, interval["end"]),
                         sub_type_label,
-                        formatLang(
-                            self.env,
-                            interval["amount"],
-                            currency_obj=self.company_currency_id,
-                        ),
-                        formatLang(
-                            self.env,
-                            sub.min_amount,
-                            currency_obj=self.company_currency_id,
-                        ),
+                        format_amount(self.env, interval["amount"], ccur),
+                        format_amount(self.env, sub.min_amount, ccur),
                     )
                 )
-        if float_is_zero(cutoff_amount, precision_rounding=prec):
+        if ccur.is_zero(cutoff_amount):
             msg = _(
                 "<p>No provision for subscription <a href=# "
                 "data-oe-model=account.cutoff.accrual.subscription "
@@ -300,6 +154,6 @@ class AccountCutoff(models.Model):
                     cutoff_amount, partner=sub.partner_id, handle_price_include=False
                 )
                 vals["tax_line_ids"] = self._prepare_tax_lines(
-                    tax_compute_all_res, company_currency
+                    tax_compute_all_res, ccur
                 )
             return vals

--- a/account_cutoff_accrual_subscription/models/account_cutoff_accrual_subscription.py
+++ b/account_cutoff_accrual_subscription/models/account_cutoff_accrual_subscription.py
@@ -2,8 +2,10 @@
 # @author: Alexis de Lattre <alexis.delattre@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from dateutil.relativedelta import relativedelta
+
 from odoo import _, api, fields, models
-from odoo.exceptions import ValidationError
+from odoo.exceptions import UserError, ValidationError
 
 
 class AccountCutoffAccrualSubscription(models.Model):
@@ -128,3 +130,121 @@ class AccountCutoffAccrualSubscription(models.Model):
     def partner_type_change(self):
         if self.partner_type != "one":
             self.partner_id = False
+
+    def _process_subscription(self, work, end_date, common_domain, sign):
+        self.ensure_one()
+        aml_obj = self.env["account.move.line"]
+        periodicity2months = {
+            "month": 1,
+            "quarter": 3,
+            "semester": 6,
+            "year": 12,
+        }
+        company = self.company_id
+        ccur = company.currency_id
+        months = periodicity2months[self.periodicity]
+        work[self] = {"intervals": [], "sub": self}
+        domain_base = common_domain + [
+            ("company_id", "=", company.id),
+            ("account_id", "=", self.account_id.id),
+            ("analytic_account_id", "=", self.analytic_account_id.id or False),
+        ]
+        if self.partner_type == "one":
+            if self.partner_id:
+                domain_base.append(("partner_id", "=", self.partner_id.id))
+            else:
+                raise UserError(
+                    _("Missing supplier on subscription '%s'.") % self.display_name
+                )
+        elif self.partner_type == "none":
+            domain_base.append(("partner_id", "=", False))
+        domain_base_w_start_end = domain_base + [
+            ("start_date", "!=", False),
+            ("end_date", "!=", False),
+        ]
+
+        for _i in range(int(12 / months)):
+            start_date = end_date + relativedelta(day=1, months=-(months - 1))
+            if start_date < self.start_date:
+                break
+            # compute amount
+            amount = 0
+            # 1. No start/end dates
+            no_start_end_res = aml_obj.read_group(
+                domain_base
+                + [
+                    ("date", "<=", end_date),
+                    ("date", ">=", start_date),
+                    ("start_date", "=", False),
+                    ("end_date", "=", False),
+                ],
+                ["balance"],
+                [],
+            )
+            amount_no_start_end = (
+                no_start_end_res and no_start_end_res[0]["balance"] or 0
+            )
+            amount += amount_no_start_end * sign
+            # 2. Start/end dates, INSIDE interval
+            inside_res = aml_obj.read_group(
+                domain_base_w_start_end
+                + [
+                    ("start_date", ">=", start_date),
+                    ("end_date", "<=", end_date),
+                ],
+                ["balance"],
+                [],
+            )
+            amount_inside = inside_res and inside_res[0]["balance"] or 0
+            amount += amount_inside * sign
+            # 3. Start/end dates, OVER interval
+            mlines = aml_obj.search(
+                domain_base_w_start_end
+                + [
+                    ("start_date", "<", start_date),
+                    ("end_date", ">", end_date),
+                ]
+            )
+            for mline in mlines:
+                total_days = (mline.end_date - mline.start_date).days + 1
+                days_in_interval = (end_date - start_date).days + 1
+                amount_in_interval = mline.balance * days_in_interval / total_days
+                amount += amount_in_interval * sign
+            # 4. Start/end dates, start_date before, end_date inside
+            mlines = aml_obj.search(
+                domain_base_w_start_end
+                + [
+                    ("start_date", "<", start_date),
+                    ("end_date", ">=", start_date),
+                    ("end_date", "<=", end_date),
+                ]
+            )
+            for mline in mlines:
+                total_days = (mline.end_date - mline.start_date).days + 1
+                days_in_interval = (mline.end_date - start_date).days + 1
+                amount_in_interval = mline.balance * days_in_interval / total_days
+                amount += amount_in_interval * sign
+            # 5. Start/end dates, start_date inside, end_date after
+            mlines = aml_obj.search(
+                domain_base_w_start_end
+                + [
+                    ("start_date", ">=", start_date),
+                    ("start_date", "<=", end_date),
+                    ("end_date", ">", end_date),
+                ]
+            )
+            for mline in mlines:
+                total_days = (mline.end_date - mline.start_date).days + 1
+                days_in_interval = (end_date - mline.start_date).days + 1
+                amount_in_interval = mline.balance * days_in_interval / total_days
+                amount += amount_in_interval * sign
+
+            work[self]["intervals"].append(
+                {
+                    "start": start_date,
+                    "end": end_date,
+                    "amount": ccur.round(amount),
+                }
+            )
+            # prepare next interval
+            end_date = start_date + relativedelta(days=-1)

--- a/account_cutoff_base/models/account_cutoff.py
+++ b/account_cutoff_base/models/account_cutoff.py
@@ -94,6 +94,12 @@ class AccountCutoff(models.Model):
         readonly=True,
         states={"draft": [("readonly", False)]},
     )
+    source_move_state = fields.Selection(
+        [("posted", "Posted Entries"), ("draft_posted", "Draft and Posted Entries")],
+        string="Source Entries",
+        required=True,
+        default="posted",
+    )
     move_id = fields.Many2one(
         "account.move",
         string="Cut-off Journal Entry",
@@ -302,6 +308,8 @@ class AccountCutoff(models.Model):
         to_provision = self._merge_provision_lines(provision_lines)
         vals = self._prepare_move(to_provision)
         move = move_obj.create(vals)
+        if self.company_id.post_cutoff_move:
+            move._post(soft=False)
         self.write({"move_id": move.id, "state": "done"})
         self.message_post(body=_("Journal entry generated"))
 

--- a/account_cutoff_base/models/res_company.py
+++ b/account_cutoff_base/models/res_company.py
@@ -19,6 +19,7 @@ class ResCompany(models.Model):
         string="Partner on Move Line by Default"
     )
     accrual_taxes = fields.Boolean(string="Accrual On Taxes", default=True)
+    post_cutoff_move = fields.Boolean(string="Post Cut-off Entry")
     default_accrued_revenue_account_id = fields.Many2one(
         comodel_name="account.account",
         string="Default Account for Accrued Revenues",

--- a/account_cutoff_base/views/account_cutoff.xml
+++ b/account_cutoff_base/views/account_cutoff.xml
@@ -65,6 +65,7 @@
                                 name="cutoff_date"
                                 options="{'datepicker': {'warn_future': true}}"
                             />
+                            <field name="source_move_state" widget="radio" />
                             <field name="total_cutoff_amount" />
                             <field
                                 name="company_id"

--- a/account_cutoff_base/views/res_config_settings.xml
+++ b/account_cutoff_base/views/res_config_settings.xml
@@ -36,6 +36,16 @@
                             </div>
                         </div>
                     </div>
+                    <div class="col-12 col-md-12 o_setting_box" id="post_cutoff_move">
+                        <div class="o_setting_left_pane">
+                            <field name="post_cutoff_move" />
+                        </div>
+                        <div class="o_setting_right_pane">
+                            <div class="row" id="post_cutoff_move_label">
+                                <label for="post_cutoff_move" class="col-md-5" />
+                            </div>
+                        </div>
+                    </div>
                     <div class="col-12 col-md-12 o_setting_box">
                         <div class="o_setting_left_pane" />
                         <div class="o_setting_right_pane">

--- a/account_cutoff_base/wizards/res_config_settings.py
+++ b/account_cutoff_base/wizards/res_config_settings.py
@@ -19,6 +19,9 @@ class ResConfigSettings(models.TransientModel):
         related="company_id.default_cutoff_move_partner", readonly=False
     )
     accrual_taxes = fields.Boolean(related="company_id.accrual_taxes", readonly=False)
+    post_cutoff_move = fields.Boolean(
+        related="company_id.post_cutoff_move", readonly=False
+    )
     dft_accrued_revenue_account_id = fields.Many2one(
         related="company_id.default_accrued_revenue_account_id",
         readonly=False,

--- a/account_cutoff_start_end_dates/models/account_cutoff.py
+++ b/account_cutoff_start_end_dates/models/account_cutoff.py
@@ -184,6 +184,10 @@ class AccountCutoff(models.Model):
             ("company_id", "=", self.company_id.id),
             ("balance", "!=", 0),
         ]
+        if self.source_move_state == "posted":
+            domain.append(("parent_state", "=", "posted"))
+        else:
+            domain.append(("parent_state", "in", ("draft", "posted")))
 
         if self.cutoff_type in ["prepaid_expense", "prepaid_revenue"]:
             if self.forecast:

--- a/account_cutoff_start_end_dates/views/account_cutoff.xml
+++ b/account_cutoff_start_end_dates/views/account_cutoff.xml
@@ -94,7 +94,7 @@
                     name="attrs"
                 >{'invisible': ['|', '|', ('line_ids', '=', False), ('state', '=', 'done'), ('forecast', '=', True)]}</attribute>
             </button>
-            <field name="cutoff_date" position="after">
+            <field name="source_move_state" position="after">
                 <field
                     name="source_journal_ids"
                     widget="many2many_tags"


### PR DESCRIPTION
1) Add option to filter source move on state "posted" or "draft and posted", following discussion on https://odoo-community.org/groups/contributors-15/contributors-255214?mode=date&date_begin=2022-10-01&date_end=2022-11-01
I decided to add this option in the "base" module because it can be useful for several additional cutoff modules.

2) Add boolean option on Accounting config page to automatically post cutoff entry