### PR TITLE
[14.0][FIX] - account_fiscal_year_closing - closing procedure compute…

### DIFF
--- a/account_fiscal_year_closing/models/account_fiscalyear_closing.py
+++ b/account_fiscal_year_closing/models/account_fiscalyear_closing.py
@@ -617,6 +617,7 @@ class AccountFiscalyearClosingMapping(models.Model):
             [
                 ("company_id", "=", company_id),
                 ("account_id", "=", account.id),
+                ("move_id.state", "!=", "cancel"),
                 ("date", ">=", start),
                 ("date", "<=", end),
             ]


### PR DESCRIPTION
FY closing procedure computes canceled entries in closing

--Process (see module instructions)--

Go to Invoicing/Accounting > Accounting > Fiscal year closing
Select your closing template and FY to be closed
Launch the procedure by clicking on "Calculate"
In the case of draft entries the system gives a warning to validate, edit or cancel them.

-- Current behavior--

The system does not detect canceled entries and computes them in the closing procedure

-- Expected behavior--

The system does not compute canceled entries in the closing procedure 