### PR TITLE
[16.0][IMP] account_invoice_start_end_dates: add start/end dates in tree view of move lines

### DIFF
--- a/account_invoice_start_end_dates/views/account_move.xml
+++ b/account_invoice_start_end_dates/views/account_move.xml
@@ -23,6 +23,18 @@
             </field>
         </field>
     </record>
+    <record id="view_move_line_tree" model="ir.ui.view">
+        <field name="name">start_end_dates.view_move_line_tree</field>
+        <field name="model">account.move.line</field>
+        <field name="inherit_id" ref="account.view_move_line_tree" />
+        <field name="arch" type="xml">
+            <field name="date_maturity" position="after">
+                <field name="must_have_dates" invisible="1" />
+                <field name="start_date" optional="hide" />
+                <field name="end_date" optional="hide" />
+            </field>
+        </field>
+    </record>
     <record id="view_move_form" model="ir.ui.view">
         <field name="name">start_end_dates.view_move_form</field>
         <field name="model">account.move</field>


### PR DESCRIPTION
It is import because we cannot access form view of account.move.line from the menu entry "Journal items" (which is not cool BTW).