### PR TITLE
[14.0] account_cutoff_accrual_picking: add prepaid support

### DIFF
--- a/account_cutoff_accrual_picking/__manifest__.py
+++ b/account_cutoff_accrual_picking/__manifest__.py
@@ -3,11 +3,11 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {
-    "name": "Account Cut-off Accrual Picking",
+    "name": "Account Cut-off Picking",
     "version": "14.0.1.2.0",
     "category": "Accounting",
     "license": "AGPL-3",
-    "summary": "Accrued expense & accrued revenue from pickings",
+    "summary": "Accrued and prepaid expense/revenue from pickings",
     "author": "Akretion,Odoo Community Association (OCA)",
     "maintainers": ["alexis-via"],
     "website": "https://github.com/OCA/account-closing",

--- a/account_cutoff_accrual_picking/models/account_cutoff.py
+++ b/account_cutoff_accrual_picking/models/account_cutoff.py
@@ -9,7 +9,7 @@ from dateutil.relativedelta import relativedelta
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
-from odoo.tools import float_is_zero
+from odoo.tools import float_compare, float_is_zero
 from odoo.tools.misc import format_date, format_datetime, formatLang
 
 
@@ -17,19 +17,20 @@ class AccountCutoff(models.Model):
     _inherit = "account.cutoff"
 
     picking_interval_days = fields.Integer(
-        string="Picking Analysis Interval",
+        string="Analysis Interval",
         default=lambda self: self._default_picking_interval_days(),
-        help="To generate the accruals based on pickings, Odoo will "
-        "analyse all the pickings between the cutoff date and N "
-        "days before. N is the Picking Analysis Interval.",
+        help="To generate the accrual/prepaid revenue/expenses based on picking "
+        "dates vs invoice dates, Odoo will analyse all the pickings/invoices from "
+        "N days before the cutoff date up to the cutoff date. "
+        "N is the Analysis Interval. If you increase the analysis interval, "
+        "Odoo will take more time to generate the cutoff lines.",
     )
 
     _sql_constraints = [
         (
             "picking_interval_days_positive",
             "CHECK(picking_interval_days > 0)",
-            "The value of the field 'Picking Analysis Interval' must "
-            "be strictly positive.",
+            "The value of the field 'Analysis Interval' must be strictly positive.",
         )
     ]
 
@@ -39,18 +40,20 @@ class AccountCutoff(models.Model):
 
     def picking_prepare_cutoff_line(self, vdict, account_mapping):
         dpo = self.env["decimal.precision"]
-        assert self.cutoff_type in (
-            "accrued_expense",
-            "accrued_revenue",
-        ), "The field 'cutoff_type' has a wrong value"
         qty_prec = dpo.precision_get("Product Unit of Measure")
-        qty = vdict["precut_delivered_qty"] - vdict["precut_invoiced_qty"]
-        if float_is_zero(qty, precision_digits=qty_prec):
+        if self.cutoff_type in ("accrued_expense", "accrued_revenue"):
+            qty = vdict["precut_delivered_qty"] - vdict["precut_invoiced_qty"]
+            qty_label = _("Pre-cutoff delivered quantity minus invoiced quantity:")
+        elif self.cutoff_type in ("prepaid_expense", "prepaid_revenue"):
+            qty = vdict["precut_invoiced_qty"] - vdict["precut_delivered_qty"]
+            qty_label = _("Pre-cutoff invoiced quantity minus delivered quantity:")
+
+        if float_compare(qty, 0, precision_digits=qty_prec) <= 0:
             return False
 
         company_currency = self.company_currency_id
         currency = vdict["currency"]
-        sign = self.cutoff_type == "accrued_expense" and -1 or 1
+        sign = self.cutoff_type in ("accrued_expense", "prepaid_revenue") and -1 or 1
         amount = qty * vdict["price_unit"] * sign
         amount_company_currency = vdict["currency"]._convert(
             amount, company_currency, self.company_id, self.cutoff_date
@@ -59,9 +62,9 @@ class AccountCutoff(models.Model):
         # Use account mapping
         account_id = vdict["account_id"]
         if account_id in account_mapping:
-            accrual_account_id = account_mapping[account_id]
+            cutoff_account_id = account_mapping[account_id]
         else:
-            accrual_account_id = account_id
+            cutoff_account_id = account_id
         uom_name = vdict["product"].uom_id.name
         notes = vdict["notes"]
         precut_delivered_qty_fl = formatLang(
@@ -97,18 +100,14 @@ class AccountCutoff(models.Model):
                 + "\n%s" % "\n".join(vdict["precut_invoiced_logs"])
             )
         qty_fl = formatLang(self.env, qty, dp="Product Unit of Measure")
-        notes += (
-            "\n"
-            + _("Pre-cutoff delivered quantity minus invoiced quantity:")
-            + " %s %s" % (qty_fl, uom_name)
-        )
+        notes += "\n%s %s %s" % (qty_label, qty_fl, uom_name)
 
         vals = {
             "parent_id": self.id,
             "partner_id": vdict["partner"].id,
             "name": vdict["name"],
             "account_id": account_id,
-            "cutoff_account_id": accrual_account_id,
+            "cutoff_account_id": cutoff_account_id,
             "analytic_account_id": vdict["analytic_account_id"],
             "currency_id": vdict["currency"].id,
             "quantity": qty,
@@ -119,7 +118,11 @@ class AccountCutoff(models.Model):
             "notes": notes,
         }
 
-        if vdict["taxes"] and self.company_id.accrual_taxes:
+        if (
+            self.cutoff_type in ("accrued_expense", "accrued_revenue")
+            and vdict["taxes"]
+            and self.company_id.accrual_taxes
+        ):
             # vdict["price_unit"] is a price without tax,
             # so I set handle_price_include=False
             tax_compute_all_res = vdict["taxes"].compute_all(
@@ -146,7 +149,14 @@ class AccountCutoff(models.Model):
         product = order_line.product_id
         product_uom = product.uom_id
         moves = order_line.move_ids
-        ilines = order_line.invoice_lines
+        if self.source_move_state == "posted":
+            ilines = order_line.invoice_lines.filtered(
+                lambda x: x.parent_state == "posted"
+            )
+        else:
+            ilines = order_line.invoice_lines.filtered(
+                lambda x: x.parent_state in ("draft", "posted")
+            )
         oline_dict[order_line] = {
             "precut_delivered_qty": 0.0,  # in product_uom
             "precut_delivered_logs": [],
@@ -156,12 +166,19 @@ class AccountCutoff(models.Model):
             "product": product,
             "partner": order.partner_id.commercial_partner_id,
             "notes": "",
+            "price_unit": 0.0,
+            "price_origin": False,
+            "currency": False,
+            "analytic_account_id": False,
+            "account_id": False,
+            "taxes": False,
         }
+        wdict = oline_dict[order_line]
         if order_type == "purchase":
             ordered_qty = order_line.product_uom._compute_quantity(
                 order_line.product_qty, product_uom
             )
-            oline_dict[order_line]["notes"] = _(
+            wdict["notes"] = _(
                 "Purchase order %s confirmed on %s\n"
                 "Purchase Order Line: %s (ordered qty: %s %s)"
             ) % (
@@ -175,7 +192,7 @@ class AccountCutoff(models.Model):
             ordered_qty = order_line.product_uom._compute_quantity(
                 order_line.product_uom_qty, product_uom
             )
-            oline_dict[order_line]["notes"] = _(
+            wdict["notes"] = _(
                 "Sale order %s confirmed on %s\n"
                 "Sale Order Line: %s (ordered qty: %s %s)"
             ) % (
@@ -202,13 +219,13 @@ class AccountCutoff(models.Model):
                     sign = order_type == "sale" and 1 or -1
                 if sign:
                     move_qty = move.product_uom._compute_quantity(
-                        move.product_uom_qty * sign, product_uom
+                        move.quantity_done * sign, product_uom
                     )
-                    oline_dict[order_line]["precut_delivered_qty"] += move_qty
+                    wdict["precut_delivered_qty"] += move_qty
                     move_qty_formatted = formatLang(
                         self.env, move_qty, dp="Product Unit of Measure"
                     )
-                    oline_dict[order_line]["precut_delivered_logs"].append(
+                    wdict["precut_delivered_logs"].append(
                         " • %s %s (picking %s transfered on %s from %s to %s)"
                         % (
                             move_qty_formatted,
@@ -220,7 +237,6 @@ class AccountCutoff(models.Model):
                         )
                     )
 
-        price_origin = False
         move_type2label = dict(
             self.env["account.move"].fields_get("move_type", "selection")["move_type"][
                 "selection"
@@ -234,11 +250,11 @@ class AccountCutoff(models.Model):
                     iline.quantity * sign, product_uom
                 )
                 if invoice.date <= self.cutoff_date:
-                    oline_dict[order_line]["precut_invoiced_qty"] += iline_qty_puom
+                    wdict["precut_invoiced_qty"] += iline_qty_puom
                     iline_qty_puom_formatted = formatLang(
                         self.env, iline_qty_puom, dp="Product Unit of Measure"
                     )
-                    oline_dict[order_line]["precut_invoiced_logs"].append(
+                    wdict["precut_invoiced_logs"].append(
                         " • %s %s (%s %s dated %s)"
                         % (
                             iline_qty_puom_formatted,
@@ -249,62 +265,61 @@ class AccountCutoff(models.Model):
                         )
                     )
                 # Most recent invoice line used for price_unit, account,...
-                price_unit = iline.price_subtotal / iline_qty_puom
-                price_origin = invoice.name
-                currency = invoice.currency_id
-                account_id = iline.account_id.id
-                analytic_account_id = iline.analytic_account_id.id
-                taxes = iline.tax_ids
-        if not price_origin:
-            if order_type == "purchase":
-                oline_qty_puom = order_line.product_uom._compute_quantity(
-                    order_line.product_qty, product_uom
-                )
-                price_unit = order_line.price_subtotal / oline_qty_puom
-                price_origin = order.name
-                currency = order.currency_id
-                analytic_account_id = order_line.account_analytic_id.id
-                taxes = order_line.taxes_id
-                account = product._get_product_accounts()["expense"]
-                if not account:
-                    raise UserError(
-                        _(
-                            "Missing expense account on product '%s' or on its "
-                            "related product category '%s'."
-                        )
-                        % (product.display_name, product.categ_id.display_name)
-                    )
-                account_id = order.fiscal_position_id.map_account(account).id
-            elif order_type == "sale":
-                oline_qty_puom = order_line.product_uom._compute_quantity(
-                    order_line.product_uom_qty, product_uom
-                )
-                price_unit = order_line.price_subtotal / oline_qty_puom
-                price_origin = order.name
-                currency = order.currency_id
-                analytic_account_id = order.analytic_account_id.id
-                taxes = order_line.tax_id
-                account = product._get_product_accounts()["income"]
-                if not account:
-                    raise UserError(
-                        _(
-                            "Missing income account on product '%s' or on its "
-                            "related product category '%s'."
-                        )
-                        % (product.display_name, product.categ_id.display_name)
-                    )
-                account_id = order.fiscal_position_id.map_account(account).id
+                wdict["price_unit"] = iline.price_subtotal / iline_qty_puom
+                wdict["price_origin"] = invoice.name
+                wdict["currency"] = invoice.currency_id
+                wdict["account_id"] = iline.account_id.id
+                wdict["analytic_account_id"] = iline.analytic_account_id.id
+                wdict["taxes"] = iline.tax_ids
+        if not wdict["price_origin"]:
+            self.order_line_update_oline_dict_price_fallback(
+                order_line, order_type, oline_dict
+            )
 
-        oline_dict[order_line].update(
-            {
-                "price_unit": price_unit,
-                "price_origin": price_origin,
-                "currency": currency,
-                "analytic_account_id": analytic_account_id,
-                "account_id": account_id,
-                "taxes": taxes,
-            }
-        )
+    def order_line_update_oline_dict_price_fallback(
+        self, order_line, order_type, oline_dict
+    ):
+        wdict = oline_dict[order_line]
+        order = order_line.order_id
+        product = order_line.product_id
+        if order_type == "purchase":
+            oline_qty_puom = order_line.product_uom._compute_quantity(
+                order_line.product_qty, product.uom_id
+            )
+            wdict["price_unit"] = order_line.price_subtotal / oline_qty_puom
+            wdict["price_origin"] = order.name
+            wdict["currency"] = order.currency_id
+            wdict["analytic_account_id"] = order_line.account_analytic_id.id
+            wdict["taxes"] = order_line.taxes_id
+            account = product._get_product_accounts()["expense"]
+            if not account:
+                raise UserError(
+                    _(
+                        "Missing expense account on product '%s' or on its "
+                        "related product category '%s'."
+                    )
+                    % (product.display_name, product.categ_id.display_name)
+                )
+            wdict["account_id"] = order.fiscal_position_id.map_account(account).id
+        elif order_type == "sale":
+            oline_qty_puom = order_line.product_uom._compute_quantity(
+                order_line.product_uom_qty, product.uom_id
+            )
+            wdict["price_unit"] = order_line.price_subtotal / oline_qty_puom
+            wdict["price_origin"] = order.name
+            wdict["currency"] = order.currency_id
+            wdict["analytic_account_id"] = order.analytic_account_id.id
+            wdict["taxes"] = order_line.tax_id
+            account = product._get_product_accounts()["income"]
+            if not account:
+                raise UserError(
+                    _(
+                        "Missing income account on product '%s' or on its "
+                        "related product category '%s'."
+                    )
+                    % (product.display_name, product.categ_id.display_name)
+                )
+            wdict["account_id"] = order.fiscal_position_id.map_account(account).id
 
     def stock_move_update_oline_dict(self, move_line, oline_dict, cutoff_datetime):
         dpo = self.env["decimal.precision"]
@@ -332,33 +347,36 @@ class AccountCutoff(models.Model):
                     move_line.sale_line_id, "sale", oline_dict, cutoff_datetime
                 )
 
+    def invoice_line_update_oline_dict(self, inv_line, oline_dict, cutoff_datetime):
+        dpo = self.env["decimal.precision"]
+        qty_prec = dpo.precision_get("Product Unit of Measure")
+        if self.cutoff_type == "prepaid_expense":
+            if (
+                inv_line.purchase_line_id
+                and inv_line.purchase_line_id not in oline_dict
+                and not float_is_zero(
+                    inv_line.purchase_line_id.product_qty, precision_digits=qty_prec
+                )
+            ):
+                self.order_line_update_oline_dict(
+                    inv_line.purchase_line_id, "purchase", oline_dict, cutoff_datetime
+                )
+        elif self.cutoff_type == "prepaid_revenue":
+            for so_line in inv_line.sale_line_ids:
+                if so_line not in oline_dict and not float_is_zero(
+                    so_line.product_uom_qty, precision_digits=qty_prec
+                ):
+                    self.order_line_update_oline_dict(
+                        so_line, "sale", oline_dict, cutoff_datetime
+                    )
+
     def get_lines(self):
         res = super().get_lines()
-        spo = self.env["stock.picking"]
         aclo = self.env["account.cutoff.line"]
 
-        pick_type_map = {
-            "accrued_revenue": "outgoing",
-            "accrued_expense": "incoming",
-        }
-        cutoff_type = self.cutoff_type
-        if cutoff_type not in pick_type_map:
-            return res
-
-        # Create account mapping dict
         account_mapping = self._get_mapping_dict()
+        cutoff_type = self.cutoff_type
         cutoff_datetime = self._get_cutoff_datetime()
-        min_date_dt = cutoff_datetime - relativedelta(days=self.picking_interval_days)
-
-        pickings = spo.search(
-            [
-                ("picking_type_code", "=", pick_type_map[cutoff_type]),
-                ("state", "=", "done"),
-                ("date_done", "<=", cutoff_datetime),
-                ("date_done", ">=", min_date_dt),
-                ("company_id", "=", self.company_id.id),
-            ]
-        )
 
         oline_dict = {}  # order line dict
         # key = PO line or SO line recordset
@@ -367,10 +385,65 @@ class AccountCutoff(models.Model):
         #   'precut_invoiced_qty': 0.0,
         #   'price_unit': 12.42,
         #   }
-        # -> we use precut_delivered_qty - precut_invoiced_qty
-        for p in pickings:
-            for move in p.move_lines.filtered(lambda m: m.state == "done"):
-                self.stock_move_update_oline_dict(move, oline_dict, cutoff_datetime)
+
+        # ACCRUAL :
+        # starting point : picking
+        # then, go to order line. From order line, go to stock moves and invoices lines
+        # => gen cutoff line if precut_delivered_qty - precut_invoiced_qty > 0
+        # PREPAID :
+        # starting point : invoice
+        # then, go to order line. From order line, go to stock moves and invoices lines
+        # => gen cutoff line if precut_invoiced_qty - precut_delivered_qty > 0
+
+        # ACCURAL
+        if cutoff_type in ("accrued_revenue", "accrued_expense"):
+            pick_type_map = {
+                "accrued_revenue": "outgoing",
+                "accrued_expense": "incoming",
+            }
+
+            min_date_dt = cutoff_datetime - relativedelta(
+                days=self.picking_interval_days
+            )
+
+            pickings = self.env["stock.picking"].search(
+                [
+                    ("picking_type_code", "=", pick_type_map[cutoff_type]),
+                    ("state", "=", "done"),
+                    ("date_done", "<=", cutoff_datetime),
+                    ("date_done", ">=", min_date_dt),
+                    ("company_id", "=", self.company_id.id),
+                ]
+            )
+
+            for p in pickings:
+                for move in p.move_lines.filtered(lambda m: m.state == "done"):
+                    self.stock_move_update_oline_dict(move, oline_dict, cutoff_datetime)
+        elif cutoff_type in ("prepaid_revenue", "prepaid_expense"):
+            move_type_map = {
+                "prepaid_revenue": ("out_invoice", "out_refund"),
+                "prepaid_expense": ("in_invoice", "in_refund"),
+            }
+            min_date = self.cutoff_date - relativedelta(days=self.picking_interval_days)
+            inv_domain = [
+                ("move_type", "in", move_type_map[cutoff_type]),
+                ("date", "<=", self.cutoff_date),
+                ("date", ">=", min_date),
+                ("company_id", "=", self.company_id.id),
+            ]
+            if self.source_move_state == "posted":
+                inv_domain.append(("state", "=", "posted"))
+            else:
+                inv_domain.append(("state", "in", ("draft", "posted")))
+            invoices = self.env["account.move"].search(inv_domain)
+            for invoice in invoices:
+                for iline in invoice.invoice_line_ids.filtered(
+                    lambda x: not x.display_type
+                    and x.product_id.type in ("product", "consu")
+                ):
+                    self.invoice_line_update_oline_dict(
+                        iline, oline_dict, cutoff_datetime
+                    )
 
         # from pprint import pprint
         # pprint(oline_dict)

--- a/account_cutoff_accrual_picking/models/account_cutoff.py
+++ b/account_cutoff_accrual_picking/models/account_cutoff.py
@@ -18,6 +18,8 @@ class AccountCutoff(models.Model):
 
     picking_interval_days = fields.Integer(
         string="Analysis Interval",
+        states={"done": [("readonly", True)]},
+        tracking=True,
         default=lambda self: self._default_picking_interval_days(),
         help="To generate the accrual/prepaid revenue/expenses based on picking "
         "dates vs invoice dates, Odoo will analyse all the pickings/invoices from "

--- a/account_cutoff_accrual_picking/models/account_cutoff.py
+++ b/account_cutoff_accrual_picking/models/account_cutoff.py
@@ -142,28 +142,14 @@ class AccountCutoff(models.Model):
         self, order_line, order_type, oline_dict, cutoff_datetime
     ):
         assert order_line not in oline_dict
-        dpo = self.env["decimal.precision"]
-        qty_prec = dpo.precision_get("Product Unit of Measure")
-        # These fields have the same name on PO and SO
-        order = order_line.order_id
-        product = order_line.product_id
-        product_uom = product.uom_id
-        moves = order_line.move_ids
-        if self.source_move_state == "posted":
-            ilines = order_line.invoice_lines.filtered(
-                lambda x: x.parent_state == "posted"
-            )
-        else:
-            ilines = order_line.invoice_lines.filtered(
-                lambda x: x.parent_state in ("draft", "posted")
-            )
+        order = order_line.order_id  # same on PO and SO
         oline_dict[order_line] = {
             "precut_delivered_qty": 0.0,  # in product_uom
             "precut_delivered_logs": [],
             "precut_invoiced_qty": 0.0,  # in product_uom
             "precut_invoiced_logs": [],
             "name": _("%s: %s") % (order.name, order_line.name),
-            "product": product,
+            "product": order_line.product_id,
             "partner": order.partner_id.commercial_partner_id,
             "notes": "",
             "price_unit": 0.0,
@@ -173,7 +159,26 @@ class AccountCutoff(models.Model):
             "account_id": False,
             "taxes": False,
         }
+        self.order_line_update_oline_dict_from_stock_moves(
+            order_line, order_type, oline_dict, cutoff_datetime
+        )
+        self.order_line_update_oline_dict_from_invoice_lines(
+            order_line, order_type, oline_dict, cutoff_datetime
+        )
+        if not oline_dict[order_line]["price_origin"]:
+            self.order_line_update_oline_dict_price_fallback(
+                order_line, order_type, oline_dict
+            )
+
+    def order_line_update_oline_dict_from_stock_moves(
+        self, order_line, order_type, oline_dict, cutoff_datetime
+    ):
         wdict = oline_dict[order_line]
+        # These fields/methods have the same name on PO and SO
+        order = order_line.order_id
+        product = order_line.product_id
+        product_uom = product.uom_id
+        outgoing_moves, incoming_moves = order_line._get_outgoing_incoming_moves()
         if order_type == "purchase":
             ordered_qty = order_line.product_uom._compute_quantity(
                 order_line.product_qty, product_uom
@@ -202,46 +207,63 @@ class AccountCutoff(models.Model):
                 formatLang(self.env, ordered_qty, dp="Product Unit of Measure"),
                 product_uom.name,
             )
-        for move in moves:
-            if move.state == "done" and move.date <= cutoff_datetime:
-                sign = 0
-                if (
-                    move.location_id.usage != "internal"
-                    and move.location_dest_id.usage == "internal"
-                ):
-                    # purchase: regular move ; sale: reverse move
-                    sign = order_type == "purchase" and 1 or -1
-                elif (
-                    move.location_id.usage == "internal"
-                    and move.location_dest_id.usage != "internal"
-                ):
-                    # purchase: reverse move ; sale: regular move
-                    sign = order_type == "sale" and 1 or -1
-                if sign:
-                    move_qty = move.product_uom._compute_quantity(
-                        move.quantity_done * sign, product_uom
-                    )
-                    wdict["precut_delivered_qty"] += move_qty
-                    move_qty_formatted = formatLang(
-                        self.env, move_qty, dp="Product Unit of Measure"
-                    )
-                    wdict["precut_delivered_logs"].append(
-                        " • %s %s (picking %s transfered on %s from %s to %s)"
-                        % (
-                            move_qty_formatted,
-                            move.product_id.uom_id.name,
-                            move.picking_id.name or "none",
-                            format_datetime(self.env, move.date),
-                            move.location_id.display_name,
-                            move.location_dest_id.display_name,
-                        )
-                    )
+        move_logs = []
+        for out_move in outgoing_moves.filtered(
+            lambda m: m.state == "done" and m.date <= cutoff_datetime
+        ):
+            sign = order_type == "purchase" and -1 or 1
+            move_qty = out_move.product_uom._compute_quantity(
+                out_move.quantity_done * sign, product_uom
+            )
+            move_logs.append((out_move, move_qty))
+        for in_move in incoming_moves.filtered(
+            lambda m: m.state == "done" and m.date <= cutoff_datetime
+        ):
+            sign = order_type == "sale" and -1 or 1
+            move_qty = in_move.product_uom._compute_quantity(
+                in_move.quantity_done * sign, product_uom
+            )
+            move_logs.append((in_move, move_qty))
+        move_logs_sorted = sorted(move_logs, key=lambda to_sort: to_sort[0].date)
+        for (move, move_qty_signed) in move_logs_sorted:
+            wdict["precut_delivered_qty"] += move_qty_signed
+            move_qty_signed_formatted = formatLang(
+                self.env, move_qty_signed, dp="Product Unit of Measure"
+            )
+            wdict["precut_delivered_logs"].append(
+                _(" • %s %s (picking %s transfered on %s from %s to %s)")
+                % (
+                    move_qty_signed_formatted,
+                    move.product_id.uom_id.name,
+                    move.picking_id.name or "none",
+                    format_datetime(self.env, move.date),
+                    move.location_id.display_name,
+                    move.location_dest_id.display_name,
+                )
+            )
 
+    def order_line_update_oline_dict_from_invoice_lines(
+        self, order_line, order_type, oline_dict, cutoff_datetime
+    ):
+        wdict = oline_dict[order_line]
+        dpo = self.env["decimal.precision"]
+        qty_prec = dpo.precision_get("Product Unit of Measure")
         move_type2label = dict(
             self.env["account.move"].fields_get("move_type", "selection")["move_type"][
                 "selection"
             ]
         )
+        # These fields have the same name on PO and SO
+        product = order_line.product_id
+        product_uom = product.uom_id
+        if self.source_move_state == "posted":
+            ilines = order_line.invoice_lines.filtered(
+                lambda x: x.parent_state == "posted"
+            )
+        else:
+            ilines = order_line.invoice_lines.filtered(
+                lambda x: x.parent_state in ("draft", "posted")
+            )
         for iline in ilines:
             invoice = iline.move_id
             if not float_is_zero(iline.quantity, precision_digits=qty_prec):
@@ -271,10 +293,6 @@ class AccountCutoff(models.Model):
                 wdict["account_id"] = iline.account_id.id
                 wdict["analytic_account_id"] = iline.analytic_account_id.id
                 wdict["taxes"] = iline.tax_ids
-        if not wdict["price_origin"]:
-            self.order_line_update_oline_dict_price_fallback(
-                order_line, order_type, oline_dict
-            )
 
     def order_line_update_oline_dict_price_fallback(
         self, order_line, order_type, oline_dict

--- a/account_cutoff_accrual_picking/models/res_company.py
+++ b/account_cutoff_accrual_picking/models/res_company.py
@@ -9,10 +9,12 @@ class ResCompany(models.Model):
     _inherit = "res.company"
 
     default_cutoff_accrual_picking_interval_days = fields.Integer(
-        string="Picking Analysis Interval",
-        help="To generate the accruals based on pickings, Odoo will "
-        "analyse all the pickings between the cutoff date and N "
-        "days before. N is the Picking Analysis Interval.",
+        string="Analysis Interval",
+        help="To generate the accrual/prepaid revenue/expenses based on picking "
+        "dates vs invoice dates, Odoo will analyse all the pickings/invoices from "
+        "N days before the cutoff date up to the cutoff date. "
+        "N is the Analysis Interval. If you increase the analysis interval, "
+        "Odoo will take more time to generate the cutoff lines.",
         default=90,
     )
 
@@ -20,7 +22,6 @@ class ResCompany(models.Model):
         (
             "cutoff_picking_interval_days_positive",
             "CHECK(default_cutoff_accrual_picking_interval_days > 0)",
-            "The value of the field 'Picking Analysis Interval' must "
-            "be strictly positive.",
+            "The value of the field 'Analysis Interval' must " "be strictly positive.",
         )
     ]

--- a/account_cutoff_accrual_picking/readme/DESCRIPTION.rst
+++ b/account_cutoff_accrual_picking/readme/DESCRIPTION.rst
@@ -1,15 +1,25 @@
-This module generates expense and revenue accruals based on the status of
-orders, pickings and invoices.
+This module generates expense/revenue accruals and prepaid expense/revenue based on the status of orders, pickings and invoices. The module is named *account_cutoff_accrual_picking* because it initially only supported accruals ; support for prepaid expense/revenue was added later (it should be renamed in later versions).
 
 To understand the behavior of this module, let's take the example of an expense accrual. When you click on the button *Re-Generate Lines* of an *Expense Accrual*:
 
-1. Odoo will look for all incoming picking in Done state with a *Transfer Date* <= *Cut-off Date* (for performance reasons, by default, the incoming picking dated before *Cut-off Date* minus 90 days will not be taken into account (this limit is configurable via the field *Picking Analysis*). It will go to the stock moves of this picking and see if they are linked to a purchase order line.
+1. Odoo will look for all incoming picking in Done state with a *Transfer Date* <= *Cut-off Date*. For performance reasons, by default, the incoming picking dated before *Cut-off Date* minus 90 days will not be taken into account (this limit is configurable via the field *Picking Analysis*). It will go to the stock moves of those pickings and see if they are linked to a purchase order line.
 2. Once this analysis is completed, Odoo has a list of purchase order lines to analyse for potential expense accrual.
 3. For each of these purchase order lines, Odoo will:
 
    - scan the related stock moves in *done* state and check their transfer date,
    - scan the related invoices lines and check their invoice date.
 
-4. If, for a particular purchase order line, the quantity of products shipped before the cutoff-date (or on the same day) minus the quantity of products invoiced before the cut-off date (or on the same day) is positive, Odoo will generate a cut-off line.
+4. If, for a particular purchase order line, the quantity of products received before the cutoff-date (or on the same day) minus the quantity of products invoiced before the cut-off date (or on the same day) is positive, Odoo will generate a cut-off line.
+
+Now, let's take the example of a prepaid expense. When you click on the button *Re-Generate Lines* of a *Prepaid Expense*:
+
+1. Odoo will look for all vendor bills dated before (or equal to) *Cut-off Date*. For performance reasons, by default, the vendor bills dated before *Cut-off Date* minus 90 days will not be taken into account (this limit is configurable via the field *Picking Analysis*). It will go to the invoice lines of those vendor bills and see if they are linked to a purchase order line.
+2. Once this analysis is completed, Odoo has a list of purchase order lines to analyse for potential prepaid expense.
+3. For each of these purchase order lines, Odoo will:
+
+   - scan the related stock moves in *done* state and check their transfer date,
+   - scan the related invoices lines and check their invoice date.
+
+4. If, for a particular purchase order line, the quantity of products invoiced before the cutoff-date (or on the same day) minus the quantity of products received before the cut-off date (or on the same day) is positive, Odoo will generate a cut-off line.
 
 This module should work well with multiple units of measure (including products purchased and invoiced in different units of measure) and in multi-currency.

--- a/account_cutoff_accrual_picking/views/account_cutoff.xml
+++ b/account_cutoff_accrual_picking/views/account_cutoff.xml
@@ -11,14 +11,8 @@
         <field name="inherit_id" ref="account_cutoff_base.account_cutoff_form" />
         <field name="arch" type="xml">
             <field name="cutoff_date" position="after">
-                <label
-                    for="picking_interval_days"
-                    attrs="{'invisible': [('cutoff_type', 'not in', ('accrued_expense', 'accrued_revenue'))]}"
-                />
-                <div
-                    name="picking_interval_days"
-                    attrs="{'invisible': [('cutoff_type', 'not in', ('accrued_expense', 'accrued_revenue'))]}"
-                >
+                <label for="picking_interval_days" />
+                <div name="picking_interval_days">
                     <field name="picking_interval_days" class="oe_inline" /> days
                 </div>
             </field>

--- a/account_cutoff_base/models/account_cutoff.py
+++ b/account_cutoff_base/models/account_cutoff.py
@@ -99,6 +99,9 @@ class AccountCutoff(models.Model):
         string="Source Entries",
         required=True,
         default="posted",
+        readonly=True,
+        states={"draft": [("readonly", False)]},
+        tracking=True,
     )
     move_id = fields.Many2one(
         "account.move",
@@ -119,6 +122,9 @@ class AccountCutoff(models.Model):
     move_partner = fields.Boolean(
         string="Partner on Move Line",
         default=lambda self: self.env.company.default_cutoff_move_partner,
+        readonly=True,
+        states={"draft": [("readonly", False)]},
+        tracking=True,
     )
     cutoff_account_id = fields.Many2one(
         comodel_name="account.account",


### PR DESCRIPTION
The module should be renamed from account_cutoff_accrual_picking to account_cutoff_picking in v16, now that it has prepaid expense/revenue support.