### PR TITLE
[13.0] Backport account_cutoff_accrual_picking from 14 to 13: add prepaid support

### DIFF
--- a/account_cutoff_accrual_base/models/account_cutoff.py
+++ b/account_cutoff_accrual_base/models/account_cutoff.py
@@ -2,7 +2,9 @@
 # @author Alexis de Lattre <alexis.delattre@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+from odoo.tools import float_is_zero
 
 
 class AccountCutOff(models.Model):
@@ -18,6 +20,46 @@ class AccountCutOff(models.Model):
         elif cutoff_type == "accrued_revenue":
             account_id = company.default_accrued_revenue_account_id.id or False
         return account_id
+
+    def _prepare_tax_lines(self, tax_compute_all_res, currency):
+        res = []
+        ato = self.env["account.tax"]
+        company_currency = self.company_id.currency_id
+        cur_rprec = company_currency.rounding
+        for tax_line in tax_compute_all_res["taxes"]:
+            tax = ato.browse(tax_line["id"])
+            if float_is_zero(tax_line["amount"], precision_rounding=cur_rprec):
+                continue
+            if self.cutoff_type == "accrued_expense":
+                tax_accrual_account_id = tax.account_accrued_expense_id.id
+                tax_account_field_label = _("Accrued Expense Tax Account")
+            elif self.cutoff_type == "accrued_revenue":
+                tax_accrual_account_id = tax.account_accrued_revenue_id.id
+                tax_account_field_label = _("Accrued Revenue Tax Account")
+            if not tax_accrual_account_id:
+                raise UserError(
+                    _("Missing '%s' on tax '%s'.")
+                    % (tax_account_field_label, tax.display_name)
+                )
+            tax_amount = currency.round(tax_line["amount"])
+            tax_accrual_amount = currency._convert(
+                tax_amount, company_currency, self.company_id, self.cutoff_date
+            )
+            res.append(
+                (
+                    0,
+                    0,
+                    {
+                        "tax_id": tax_line["id"],
+                        "base": tax_line["base"],  # in currency
+                        "amount": tax_amount,  # in currency
+                        "sequence": tax_line["sequence"],
+                        "cutoff_account_id": tax_accrual_account_id,
+                        "cutoff_amount": tax_accrual_amount,  # in company currency
+                    },
+                )
+            )
+        return res
 
 
 class AccountCutoffLine(models.Model):

--- a/account_cutoff_accrual_base/views/res_config_settings.xml
+++ b/account_cutoff_accrual_base/views/res_config_settings.xml
@@ -12,31 +12,37 @@
             ref="account_cutoff_base.res_config_settings_view_form"
         />
         <field name="arch" type="xml">
-            <field name="dft_cutoff_journal_id" position="after">
+            <div id="dft_cutoff_journal_id" position="after">
+                <div class="row" id="dft_accrued_revenue_account_id">
                 <label
-                    for="dft_accrued_revenue_account_id"
-                    class="col-lg-3 o_light_label"
-                />
+                        for="dft_accrued_revenue_account_id"
+                        class="col-lg-4 o_light_label"
+                    />
                 <field
-                    name="dft_accrued_revenue_account_id"
-                    domain="[('company_id', '=', company_id)]"
-                    options="{'no_create_edit': True, 'no_open': True}"
-                />
+                        name="dft_accrued_revenue_account_id"
+                        domain="[('company_id', '=', company_id)]"
+                        options="{'no_create_edit': True, 'no_open': True}"
+                    />
+                </div>
+                <div class="row" id="dft_accrued_expense_account_id">
                 <label
-                    for="dft_accrued_expense_account_id"
-                    class="col-lg-3 o_light_label"
-                />
+                        for="dft_accrued_expense_account_id"
+                        class="col-lg-4 o_light_label"
+                    />
                 <field
-                    name="dft_accrued_expense_account_id"
-                    domain="[('company_id', '=', company_id)]"
-                    options="{'no_create_edit': True, 'no_open': True}"
-                />
-                <label for="accrual_taxes" class="col-lg-3 o_light_label" />
+                        name="dft_accrued_expense_account_id"
+                        domain="[('company_id', '=', company_id)]"
+                        options="{'no_create_edit': True, 'no_open': True}"
+                    />
+                </div>
+                <div class="row" id="accrual_taxes">
+                <label for="accrual_taxes" class="col-lg-4 o_light_label" />
                 <field
-                    name="accrual_taxes"
-                    options="{'no_create_edit': True, 'no_open': True}"
-                />
-            </field>
+                        name="accrual_taxes"
+                        options="{'no_create_edit': True, 'no_open': True}"
+                    />
+                </div>
+            </div>
         </field>
     </record>
 </odoo>

--- a/account_cutoff_accrual_picking/__manifest__.py
+++ b/account_cutoff_accrual_picking/__manifest__.py
@@ -3,11 +3,11 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {
-    "name": "Account Cut-off Accrual Picking",
+    "name": "Account Cut-off Picking",
     "version": "13.0.1.0.1",
     "category": "Accounting",
     "license": "AGPL-3",
-    "summary": "Accrued expense & accrued revenue from pickings",
+    "summary": "Accrued and prepaid expense/revenue from pickings",
     "author": "Akretion,Odoo Community Association (OCA)",
     "maintainers": ["alexis-via"],
     "website": "https://github.com/OCA/account-closing",

--- a/account_cutoff_accrual_picking/models/account_cutoff.py
+++ b/account_cutoff_accrual_picking/models/account_cutoff.py
@@ -18,6 +18,8 @@ class AccountCutoff(models.Model):
 
     picking_interval_days = fields.Integer(
         string="Analysis Interval",
+        states={"done": [("readonly", True)]},
+        tracking=True,
         default=lambda self: self._default_picking_interval_days(),
         help="To generate the accrual/prepaid revenue/expenses based on picking "
         "dates vs invoice dates, Odoo will analyse all the pickings/invoices from "

--- a/account_cutoff_accrual_picking/models/account_cutoff.py
+++ b/account_cutoff_accrual_picking/models/account_cutoff.py
@@ -2,30 +2,35 @@
 # @author: Alexis de Lattre <alexis.delattre@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from datetime import datetime
+
+import pytz
 from dateutil.relativedelta import relativedelta
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 from odoo.tools import float_compare, float_is_zero
+from odoo.tools.misc import format_date, format_datetime, formatLang
 
 
 class AccountCutoff(models.Model):
     _inherit = "account.cutoff"
 
     picking_interval_days = fields.Integer(
-        string="Picking Analysis Interval",
+        string="Analysis Interval",
         default=lambda self: self._default_picking_interval_days(),
-        help="To generate the accruals based on pickings, Odoo will "
-        "analyse all the pickings between the cutoff date and N "
-        "days before. N is the Picking Analysis Interval.",
+        help="To generate the accrual/prepaid revenue/expenses based on picking "
+        "dates vs invoice dates, Odoo will analyse all the pickings/invoices from "
+        "N days before the cutoff date up to the cutoff date. "
+        "N is the Analysis Interval. If you increase the analysis interval, "
+        "Odoo will take more time to generate the cutoff lines.",
     )
 
     _sql_constraints = [
         (
             "picking_interval_days_positive",
             "CHECK(picking_interval_days > 0)",
-            "The value of the field 'Picking Analysis Interval' must "
-            "be strictly positive.",
+            "The value of the field 'Analysis Interval' must be strictly positive.",
         )
     ]
 
@@ -34,80 +39,71 @@ class AccountCutoff(models.Model):
         return self.env.company.default_cutoff_accrual_picking_interval_days
 
     def picking_prepare_cutoff_line(self, vdict, account_mapping):
-        ato = self.env["account.tax"]
         dpo = self.env["decimal.precision"]
-        assert self.cutoff_type in (
-            "accrued_expense",
-            "accrued_revenue",
-        ), "The field 'cutoff_type' has a wrong value"
         qty_prec = dpo.precision_get("Product Unit of Measure")
-        cur_rprec = vdict["currency"].rounding
-        qty = vdict["precut_delivered_qty"] - vdict["precut_invoiced_qty"]
-        if float_is_zero(qty, precision_digits=qty_prec):
+        if self.cutoff_type in ("accrued_expense", "accrued_revenue"):
+            qty = vdict["precut_delivered_qty"] - vdict["precut_invoiced_qty"]
+            qty_label = _("Pre-cutoff delivered quantity minus invoiced quantity:")
+        elif self.cutoff_type in ("prepaid_expense", "prepaid_revenue"):
+            qty = vdict["precut_invoiced_qty"] - vdict["precut_delivered_qty"]
+            qty_label = _("Pre-cutoff invoiced quantity minus delivered quantity:")
+
+        if float_compare(qty, 0, precision_digits=qty_prec) <= 0:
             return False
 
         company_currency = self.company_currency_id
         currency = vdict["currency"]
-        sign = self.cutoff_type == "accrued_expense" and -1 or 1
+        sign = self.cutoff_type in ("accrued_expense", "prepaid_revenue") and -1 or 1
         amount = qty * vdict["price_unit"] * sign
         amount_company_currency = vdict["currency"]._convert(
             amount, company_currency, self.company_id, self.cutoff_date
         )
 
-        tax_line_ids = []
-        tax_res = vdict["taxes"].compute_all(
-            vdict["price_unit"],
-            currency=currency,
-            quantity=qty,
-            product=vdict["product"],
-            partner=vdict["partner"],
-        )
-        for tax_line in tax_res["taxes"]:
-            tax = ato.browse(tax_line["id"])
-            if float_is_zero(tax_line["amount"], precision_rounding=cur_rprec):
-                continue
-            if self.cutoff_type == "accrued_expense":
-                tax_accrual_account_id = tax.account_accrued_expense_id.id
-                tax_account_field_label = _("Accrued Expense Tax Account")
-            elif self.cutoff_type == "accrued_revenue":
-                tax_accrual_account_id = tax.account_accrued_revenue_id.id
-                tax_account_field_label = _("Accrued Revenue Tax Account")
-            if not tax_accrual_account_id:
-                raise UserError(
-                    _("Missing '%s' on tax '%s'.")
-                    % (tax_account_field_label, tax.display_name)
-                )
-            tax_amount = tax_line["amount"] * sign
-            tax_accrual_amount = currency._convert(
-                tax_amount, company_currency, self.company_id, self.cutoff_date
-            )
-            tax_line_ids.append(
-                (
-                    0,
-                    0,
-                    {
-                        "tax_id": tax_line["id"],
-                        "base": tax_line["base"],
-                        "amount": tax_amount,
-                        "sequence": tax_line["sequence"],
-                        "cutoff_account_id": tax_accrual_account_id,
-                        "cutoff_amount": tax_accrual_amount,
-                    },
-                )
-            )
-
         # Use account mapping
         account_id = vdict["account_id"]
         if account_id in account_mapping:
-            accrual_account_id = account_mapping[account_id]
+            cutoff_account_id = account_mapping[account_id]
         else:
-            accrual_account_id = account_id
+            cutoff_account_id = account_id
+        uom_name = vdict["product"].uom_id.name
+        notes = vdict["notes"]
+        precut_delivered_qty_fl = formatLang(
+            self.env, vdict.get("precut_delivered_qty", 0), dp="Product Unit of Measure"
+        )
+        notes += (
+            "\n"
+            + _("Pre-cutoff delivered quantity:")
+            + " %s %s" % (precut_delivered_qty_fl, uom_name,)
+        )
+        if vdict.get("precut_delivered_logs"):
+            notes += (
+                "\n"
+                + _("Pre-cutoff delivered quantity details:")
+                + "\n%s" % "\n".join(vdict["precut_delivered_logs"])
+            )
+        precut_invoiced_qty_fl = formatLang(
+            self.env, vdict.get("precut_invoiced_qty", 0), dp="Product Unit of Measure"
+        )
+        notes += (
+            "\n"
+            + _("Pre-cutoff invoiced quantity:")
+            + " %s %s" % (precut_invoiced_qty_fl, uom_name)
+        )
+        if vdict.get("precut_invoiced_logs"):
+            notes += (
+                "\n"
+                + _("Pre-cutoff invoiced quantity details:")
+                + "\n%s" % "\n".join(vdict["precut_invoiced_logs"])
+            )
+        qty_fl = formatLang(self.env, qty, dp="Product Unit of Measure")
+        notes += "\n%s %s %s" % (qty_label, qty_fl, uom_name)
+
         vals = {
             "parent_id": self.id,
             "partner_id": vdict["partner"].id,
             "name": vdict["name"],
             "account_id": account_id,
-            "cutoff_account_id": accrual_account_id,
+            "cutoff_account_id": cutoff_account_id,
             "analytic_account_id": vdict["analytic_account_id"],
             "currency_id": vdict["currency"].id,
             "quantity": qty,
@@ -115,12 +111,33 @@ class AccountCutoff(models.Model):
             "tax_ids": [(6, 0, vdict["taxes"].ids)],
             "amount": amount,
             "cutoff_amount": amount_company_currency,
-            "tax_line_ids": tax_line_ids,
             "price_origin": vdict.get("price_origin"),
+            "notes": notes,
         }
+
+        if (
+            self.cutoff_type in ("accrued_expense", "accrued_revenue")
+            and vdict["taxes"]
+            and self.company_id.accrual_taxes
+        ):
+            # vdict["price_unit"] is a price without tax,
+            # so I set handle_price_include=False
+            tax_compute_all_res = vdict["taxes"].compute_all(
+                vdict["price_unit"],
+                currency=currency,
+                quantity=qty * sign,
+                product=vdict["product"],
+                partner=vdict["partner"],
+                handle_price_include=False,
+            )
+            vals["tax_line_ids"] = self._prepare_tax_lines(
+                tax_compute_all_res, self.company_currency_id
+            )
         return vals
 
-    def order_line_update_oline_dict(self, order_line, order_type, oline_dict):
+    def order_line_update_oline_dict(
+        self, order_line, order_type, oline_dict, cutoff_datetime
+    ):
         assert order_line not in oline_dict
         dpo = self.env["decimal.precision"]
         qty_prec = dpo.precision_get("Product Unit of Measure")
@@ -129,98 +146,179 @@ class AccountCutoff(models.Model):
         product = order_line.product_id
         product_uom = product.uom_id
         moves = order_line.move_ids
-        ilines = order_line.invoice_lines
+        if self.source_move_state == "posted":
+            ilines = order_line.invoice_lines.filtered(
+                lambda x: x.parent_state == "posted"
+            )
+        else:
+            ilines = order_line.invoice_lines.filtered(
+                lambda x: x.parent_state in ("draft", "posted")
+            )
         oline_dict[order_line] = {
             "precut_delivered_qty": 0.0,  # in product_uom
+            "precut_delivered_logs": [],
             "precut_invoiced_qty": 0.0,  # in product_uom
-            "name": _("%s line ID %d: %s")
-            % (order.name, order_line.id, order_line.name),
+            "precut_invoiced_logs": [],
+            "name": _("%s: %s") % (order.name, order_line.name),
             "product": product,
             "partner": order.partner_id.commercial_partner_id,
+            "notes": "",
+            "price_unit": 0.0,
+            "price_origin": False,
+            "currency": False,
+            "analytic_account_id": False,
+            "account_id": False,
+            "taxes": False,
         }
+        wdict = oline_dict[order_line]
         if order_type == "purchase":
-            invoice_type = "in_invoice"
+            ordered_qty = order_line.product_uom._compute_quantity(
+                order_line.product_qty, product_uom
+            )
+            wdict["notes"] = _(
+                "Purchase order %s confirmed on %s\n"
+                "Purchase Order Line: %s (ordered qty: %s %s)"
+            ) % (
+                order.name,
+                format_datetime(self.env, order.date_approve),
+                order_line.name,
+                formatLang(self.env, ordered_qty, dp="Product Unit of Measure"),
+                product_uom.name,
+            )
         elif order_type == "sale":
-            invoice_type = "out_invoice"
+            ordered_qty = order_line.product_uom._compute_quantity(
+                order_line.product_uom_qty, product_uom
+            )
+            wdict["notes"] = _(
+                "Sale order %s confirmed on %s\n"
+                "Sale Order Line: %s (ordered qty: %s %s)"
+            ) % (
+                order.name,
+                format_datetime(self.env, order.date_order),
+                order_line.name,
+                formatLang(self.env, ordered_qty, dp="Product Unit of Measure"),
+                product_uom.name,
+            )
         for move in moves:
-            # TODO: improve comparaison of date and datetime
-            # for our friends far away from GMT
-            if move.state == "done" and move.date.date() <= self.cutoff_date:
-                move_qty = move.product_uom._compute_quantity(
-                    move.product_uom_qty, product_uom
-                )
-                oline_dict[order_line]["precut_delivered_qty"] += move_qty
-        price_origin = False
+            if move.state == "done" and move.date <= cutoff_datetime:
+                sign = 0
+                if (
+                    move.location_id.usage != "internal"
+                    and move.location_dest_id.usage == "internal"
+                ):
+                    # purchase: regular move ; sale: reverse move
+                    sign = order_type == "purchase" and 1 or -1
+                elif (
+                    move.location_id.usage == "internal"
+                    and move.location_dest_id.usage != "internal"
+                ):
+                    # purchase: reverse move ; sale: regular move
+                    sign = order_type == "sale" and 1 or -1
+                if sign:
+                    move_qty = move.product_uom._compute_quantity(
+                        move.quantity_done * sign, product_uom
+                    )
+                    wdict["precut_delivered_qty"] += move_qty
+                    move_qty_formatted = formatLang(
+                        self.env, move_qty, dp="Product Unit of Measure"
+                    )
+                    wdict["precut_delivered_logs"].append(
+                        " • %s %s (picking %s transfered on %s from %s to %s)"
+                        % (
+                            move_qty_formatted,
+                            move.product_id.uom_id.name,
+                            move.picking_id.name or "none",
+                            format_datetime(self.env, move.date),
+                            move.location_id.display_name,
+                            move.location_dest_id.display_name,
+                        )
+                    )
+
+        move_type2label = dict(
+            self.env["account.move"].fields_get("type", "selection")["type"][
+                "selection"
+            ]
+        )
         for iline in ilines:
             invoice = iline.move_id
-            if (
-                invoice.type == invoice_type
-                and float_compare(iline.quantity, 0, precision_digits=qty_prec) > 0
-            ):
+            if not float_is_zero(iline.quantity, precision_digits=qty_prec):
+                sign = invoice.type in ("out_refund", "in_refund") and -1 or 1
                 iline_qty_puom = iline.product_uom_id._compute_quantity(
-                    iline.quantity, product_uom
+                    iline.quantity * sign, product_uom
                 )
                 if invoice.date <= self.cutoff_date:
-                    oline_dict[order_line]["precut_invoiced_qty"] += iline_qty_puom
+                    wdict["precut_invoiced_qty"] += iline_qty_puom
+                    iline_qty_puom_formatted = formatLang(
+                        self.env, iline_qty_puom, dp="Product Unit of Measure"
+                    )
+                    wdict["precut_invoiced_logs"].append(
+                        " • %s %s (%s %s dated %s)"
+                        % (
+                            iline_qty_puom_formatted,
+                            iline.product_id.uom_id.name,
+                            move_type2label[invoice.type],
+                            invoice.name,
+                            format_date(self.env, invoice.date),
+                        )
+                    )
                 # Most recent invoice line used for price_unit, account,...
-                price_unit = iline.price_subtotal / iline_qty_puom
-                price_origin = _("Invoice %s line ID %d") % (invoice.name, iline.id)
-                currency = invoice.currency_id
-                account_id = iline.account_id.id
-                analytic_account_id = iline.analytic_account_id.id
-                taxes = iline.tax_ids
-        if not price_origin:
-            if order_type == "purchase":
-                oline_qty_puom = order_line.product_uom._compute_quantity(
-                    order_line.product_qty, product_uom
-                )
-                price_unit = order_line.price_subtotal / oline_qty_puom
-                price_origin = _("%s line ID %d") % (order.name, order_line.id)
-                currency = order.currency_id
-                analytic_account_id = order_line.account_analytic_id.id
-                taxes = order_line.taxes_id
-                account = product.product_tmpl_id._get_product_accounts()["expense"]
-                if not account:
-                    raise UserError(
-                        _(
-                            "Missing expense account on product '%s' or on its "
-                            "related product category '%s'."
-                        )
-                        % (product.display_name, product.categ_id.display_name)
-                    )
-                account_id = order.fiscal_position_id.map_account(account).id
-            elif order_type == "sale":
-                oline_qty_puom = order_line.product_uom._compute_quantity(
-                    order_line.product_uom_qty, product_uom
-                )
-                price_unit = order_line.price_subtotal / oline_qty_puom
-                price_origin = "%s line ID %d" % (order.name, order_line.id)
-                currency = order.currency_id
-                analytic_account_id = order.analytic_account_id.id
-                taxes = order_line.tax_id
-                account = product.product_tmpl_id._get_product_accounts()["income"]
-                if not account:
-                    raise UserError(
-                        _(
-                            "Missing income account on product '%s' or on its "
-                            "related product category '%s'."
-                        )
-                        % (product.display_name, product.categ_id.display_name)
-                    )
-                account_id = order.fiscal_position_id.map_account(account).id
+                wdict["price_unit"] = iline.price_subtotal / iline_qty_puom
+                wdict["price_origin"] = invoice.name
+                wdict["currency"] = invoice.currency_id
+                wdict["account_id"] = iline.account_id.id
+                wdict["analytic_account_id"] = iline.analytic_account_id.id
+                wdict["taxes"] = iline.tax_ids
+        if not wdict["price_origin"]:
+            self.order_line_update_oline_dict_price_fallback(
+                order_line, order_type, oline_dict
+            )
 
-        oline_dict[order_line].update(
-            {
-                "price_unit": price_unit,
-                "price_origin": price_origin,
-                "currency": currency,
-                "analytic_account_id": analytic_account_id,
-                "account_id": account_id,
-                "taxes": taxes,
-            }
-        )
+    def order_line_update_oline_dict_price_fallback(
+        self, order_line, order_type, oline_dict
+    ):
+        wdict = oline_dict[order_line]
+        order = order_line.order_id
+        product = order_line.product_id
+        if order_type == "purchase":
+            oline_qty_puom = order_line.product_uom._compute_quantity(
+                order_line.product_qty, product.uom_id
+            )
+            wdict["price_unit"] = order_line.price_subtotal / oline_qty_puom
+            wdict["price_origin"] = order.name
+            wdict["currency"] = order.currency_id
+            wdict["analytic_account_id"] = order_line.account_analytic_id.id
+            wdict["taxes"] = order_line.taxes_id
+            account = product.product_tmpl_id._get_product_accounts()["expense"]
+            if not account:
+                raise UserError(
+                    _(
+                        "Missing expense account on product '%s' or on its "
+                        "related product category '%s'."
+                    )
+                    % (product.display_name, product.categ_id.display_name)
+                )
+            wdict["account_id"] = order.fiscal_position_id.map_account(account).id
+        elif order_type == "sale":
+            oline_qty_puom = order_line.product_uom._compute_quantity(
+                order_line.product_uom_qty, product.uom_id
+            )
+            wdict["price_unit"] = order_line.price_subtotal / oline_qty_puom
+            wdict["price_origin"] = order.name
+            wdict["currency"] = order.currency_id
+            wdict["analytic_account_id"] = order.analytic_account_id.id
+            wdict["taxes"] = order_line.tax_id
+            account = product.product_tmpl_id._get_product_accounts()["income"]
+            if not account:
+                raise UserError(
+                    _(
+                        "Missing income account on product '%s' or on its "
+                        "related product category '%s'."
+                    )
+                    % (product.display_name, product.categ_id.display_name)
+                )
+            wdict["account_id"] = order.fiscal_position_id.map_account(account).id
 
-    def stock_move_update_oline_dict(self, move_line, oline_dict):
+    def stock_move_update_oline_dict(self, move_line, oline_dict, cutoff_datetime):
         dpo = self.env["decimal.precision"]
         qty_prec = dpo.precision_get("Product Unit of Measure")
         if self.cutoff_type == "accrued_expense":
@@ -232,7 +330,7 @@ class AccountCutoff(models.Model):
                 )
             ):
                 self.order_line_update_oline_dict(
-                    move_line.purchase_line_id, "purchase", oline_dict
+                    move_line.purchase_line_id, "purchase", oline_dict, cutoff_datetime
                 )
         elif self.cutoff_type == "accrued_revenue":
             if (
@@ -243,39 +341,41 @@ class AccountCutoff(models.Model):
                 )
             ):
                 self.order_line_update_oline_dict(
-                    move_line.sale_line_id, "sale", oline_dict
+                    move_line.sale_line_id, "sale", oline_dict, cutoff_datetime
                 )
+
+    def invoice_line_update_oline_dict(self, inv_line, oline_dict, cutoff_datetime):
+        dpo = self.env["decimal.precision"]
+        qty_prec = dpo.precision_get("Product Unit of Measure")
+        if self.cutoff_type == "prepaid_expense":
+            if (
+                inv_line.purchase_line_id
+                and inv_line.purchase_line_id not in oline_dict
+                and not float_is_zero(
+                    inv_line.purchase_line_id.product_qty, precision_digits=qty_prec
+                )
+            ):
+                self.order_line_update_oline_dict(
+                    inv_line.purchase_line_id, "purchase", oline_dict, cutoff_datetime
+                )
+        elif self.cutoff_type == "prepaid_revenue":
+            for so_line in inv_line.sale_line_ids:
+                if so_line not in oline_dict and not float_is_zero(
+                    so_line.product_uom_qty, precision_digits=qty_prec
+                ):
+                    self.order_line_update_oline_dict(
+                        so_line, "sale", oline_dict, cutoff_datetime
+                    )
 
     def get_lines(self):
         res = super().get_lines()
-        spo = self.env["stock.picking"]
         aclo = self.env["account.cutoff.line"]
-        acmo = self.env["account.cutoff.mapping"]
 
-        pick_type_map = {
-            "accrued_revenue": "outgoing",
-            "accrued_expense": "incoming",
-        }
-        cutoff_type = self.cutoff_type
-        if cutoff_type not in pick_type_map:
-            return res
-
-        # Create account mapping dict
-        account_mapping = acmo._get_mapping_dict(self.company_id.id, cutoff_type)
-
-        min_date_dt = self.cutoff_date - relativedelta(days=self.picking_interval_days)
-
-        # TODO date_done is a Datetime field, so maybe we need more clever code
-        # for our friends which are far away from GMT
-        pickings = spo.search(
-            [
-                ("picking_type_code", "=", pick_type_map[cutoff_type]),
-                ("state", "=", "done"),
-                ("date_done", "<=", self.cutoff_date),
-                ("date_done", ">=", min_date_dt),
-                ("company_id", "=", self.company_id.id),
-            ]
+        account_mapping = self.env["account.cutoff.mapping"]._get_mapping_dict(
+            self.company_id.id
         )
+        cutoff_type = self.cutoff_type
+        cutoff_datetime = self._get_cutoff_datetime()
 
         oline_dict = {}  # order line dict
         # key = PO line or SO line recordset
@@ -284,10 +384,65 @@ class AccountCutoff(models.Model):
         #   'precut_invoiced_qty': 0.0,
         #   'price_unit': 12.42,
         #   }
-        # -> we use precut_delivered_qty - precut_invoiced_qty
-        for p in pickings:
-            for move in p.move_lines.filtered(lambda m: m.state == "done"):
-                self.stock_move_update_oline_dict(move, oline_dict)
+
+        # ACCRUAL :
+        # starting point : picking
+        # then, go to order line. From order line, go to stock moves and invoices lines
+        # => gen cutoff line if precut_delivered_qty - precut_invoiced_qty > 0
+        # PREPAID :
+        # starting point : invoice
+        # then, go to order line. From order line, go to stock moves and invoices lines
+        # => gen cutoff line if precut_invoiced_qty - precut_delivered_qty > 0
+
+        # ACCURAL
+        if cutoff_type in ("accrued_revenue", "accrued_expense"):
+            pick_type_map = {
+                "accrued_revenue": "outgoing",
+                "accrued_expense": "incoming",
+            }
+
+            min_date_dt = cutoff_datetime - relativedelta(
+                days=self.picking_interval_days
+            )
+
+            pickings = self.env["stock.picking"].search(
+                [
+                    ("picking_type_code", "=", pick_type_map[cutoff_type]),
+                    ("state", "=", "done"),
+                    ("date_done", "<=", cutoff_datetime),
+                    ("date_done", ">=", min_date_dt),
+                    ("company_id", "=", self.company_id.id),
+                ]
+            )
+
+            for p in pickings:
+                for move in p.move_lines.filtered(lambda m: m.state == "done"):
+                    self.stock_move_update_oline_dict(move, oline_dict, cutoff_datetime)
+        elif cutoff_type in ("prepaid_revenue", "prepaid_expense"):
+            move_type_map = {
+                "prepaid_revenue": ("out_invoice", "out_refund"),
+                "prepaid_expense": ("in_invoice", "in_refund"),
+            }
+            min_date = self.cutoff_date - relativedelta(days=self.picking_interval_days)
+            inv_domain = [
+                ("type", "in", move_type_map[cutoff_type]),
+                ("date", "<=", self.cutoff_date),
+                ("date", ">=", min_date),
+                ("company_id", "=", self.company_id.id),
+            ]
+            if self.source_move_state == "posted":
+                inv_domain.append(("state", "=", "posted"))
+            else:
+                inv_domain.append(("state", "in", ("draft", "posted")))
+            invoices = self.env["account.move"].search(inv_domain)
+            for invoice in invoices:
+                for iline in invoice.invoice_line_ids.filtered(
+                    lambda x: not x.display_type
+                    and x.product_id.type in ("product", "consu")
+                ):
+                    self.invoice_line_update_oline_dict(
+                        iline, oline_dict, cutoff_datetime
+                    )
 
         # from pprint import pprint
         # pprint(oline_dict)
@@ -296,3 +451,12 @@ class AccountCutoff(models.Model):
             if vals:
                 aclo.create(vals)
         return res
+
+    def _get_cutoff_datetime(self):
+        self.ensure_one()
+        cutoff_date = datetime.combine(self.cutoff_date, datetime.max.time())
+        tz = self.env.user.tz and pytz.timezone(self.env.user.tz) or pytz.utc
+        cutoff_datetime_aware = tz.localize(cutoff_date)
+        cutoff_datetime_utc = cutoff_datetime_aware.astimezone(pytz.utc)
+        cutoff_datetime_utc_naive = cutoff_datetime_utc.replace(tzinfo=None)
+        return cutoff_datetime_utc_naive

--- a/account_cutoff_accrual_picking/models/company.py
+++ b/account_cutoff_accrual_picking/models/company.py
@@ -1,4 +1,5 @@
-# Copyright 2020 Akretion France
+# Copyright 2020-2021 Akretion France (http://www.akretion.com/)
+# @author: Alexis de Lattre <alexis.delattre@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 from odoo import fields, models
@@ -8,10 +9,12 @@ class ResCompany(models.Model):
     _inherit = "res.company"
 
     default_cutoff_accrual_picking_interval_days = fields.Integer(
-        string="Picking Analysis Interval",
-        help="To generate the accruals based on pickings, Odoo will "
-        "analyse all the pickings between the cutoff date and N "
-        "days before. N is the Picking Analysis Interval.",
+        string="Analysis Interval",
+        help="To generate the accrual/prepaid revenue/expenses based on picking "
+        "dates vs invoice dates, Odoo will analyse all the pickings/invoices from "
+        "N days before the cutoff date up to the cutoff date. "
+        "N is the Analysis Interval. If you increase the analysis interval, "
+        "Odoo will take more time to generate the cutoff lines.",
         default=90,
     )
 
@@ -19,7 +22,6 @@ class ResCompany(models.Model):
         (
             "cutoff_picking_interval_days_positive",
             "CHECK(default_cutoff_accrual_picking_interval_days > 0)",
-            "The value of the field 'Picking Analysis Interval' must "
-            "be strictly positive.",
+            "The value of the field 'Analysis Interval' must " "be strictly positive.",
         )
     ]

--- a/account_cutoff_accrual_picking/models/res_config_settings.py
+++ b/account_cutoff_accrual_picking/models/res_config_settings.py
@@ -8,8 +8,8 @@ from odoo import fields, models
 class ResConfigSettings(models.TransientModel):
     _inherit = "res.config.settings"
 
-    # I can't name it default_cutoff_journal_id
-    # because default_ is a special prefix
+    # I can't name it default_cutoff_accrual_picking_interval_days
+    # because 'default_' is a special prefix
     dft_cutoff_accrual_picking_interval_days = fields.Integer(
         related="company_id.default_cutoff_accrual_picking_interval_days",
         readonly=False,

--- a/account_cutoff_accrual_picking/readme/DESCRIPTION.rst
+++ b/account_cutoff_accrual_picking/readme/DESCRIPTION.rst
@@ -1,15 +1,25 @@
-This module generates expense and revenue accruals based on the status of
-orders, pickings and invoices.
+This module generates expense/revenue accruals and prepaid expense/revenue based on the status of orders, pickings and invoices. The module is named *account_cutoff_accrual_picking* because it initially only supported accruals ; support for prepaid expense/revenue was added later (it should be renamed in later versions).
 
 To understand the behavior of this module, let's take the example of an expense accrual. When you click on the button *Re-Generate Lines* of an *Expense Accrual*:
 
-1. Odoo will look for all incoming picking in Done state with a *Transfer Date* <= *Cut-off Date* (for performance reasons, by default, the incoming picking dated before *Cut-off Date* minus 3 months will not be taken into account (this limit can be easily changed via a method inheritance). It will go to the stock moves of this picking and see if they are linked to a purchase order line.
+1. Odoo will look for all incoming picking in Done state with a *Transfer Date* <= *Cut-off Date*. For performance reasons, by default, the incoming picking dated before *Cut-off Date* minus 90 days will not be taken into account (this limit is configurable via the field *Picking Analysis*). It will go to the stock moves of those pickings and see if they are linked to a purchase order line.
 2. Once this analysis is completed, Odoo has a list of purchase order lines to analyse for potential expense accrual.
 3. For each of these purchase order lines, Odoo will:
 
    - scan the related stock moves in *done* state and check their transfer date,
-   - scan the related invoices lines in *open* or *paid* state and check their invoice date.
+   - scan the related invoices lines and check their invoice date.
 
-4. If, for a particular purchase order line, the quantity of products shipped before the cutoff-date (or on the same day) minus the quantity of products invoiced before the cut-off date (or on the same day) is positive, Odoo will generate a cut-off line.
+4. If, for a particular purchase order line, the quantity of products received before the cutoff-date (or on the same day) minus the quantity of products invoiced before the cut-off date (or on the same day) is positive, Odoo will generate a cut-off line.
+
+Now, let's take the example of a prepaid expense. When you click on the button *Re-Generate Lines* of a *Prepaid Expense*:
+
+1. Odoo will look for all vendor bills dated before (or equal to) *Cut-off Date*. For performance reasons, by default, the vendor bills dated before *Cut-off Date* minus 90 days will not be taken into account (this limit is configurable via the field *Picking Analysis*). It will go to the invoice lines of those vendor bills and see if they are linked to a purchase order line.
+2. Once this analysis is completed, Odoo has a list of purchase order lines to analyse for potential prepaid expense.
+3. For each of these purchase order lines, Odoo will:
+
+   - scan the related stock moves in *done* state and check their transfer date,
+   - scan the related invoices lines and check their invoice date.
+
+4. If, for a particular purchase order line, the quantity of products invoiced before the cutoff-date (or on the same day) minus the quantity of products received before the cut-off date (or on the same day) is positive, Odoo will generate a cut-off line.
 
 This module should work well with multiple units of measure (including products purchased and invoiced in different units of measure) and in multi-currency.

--- a/account_cutoff_accrual_picking/views/account_cutoff.xml
+++ b/account_cutoff_accrual_picking/views/account_cutoff.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!--
-  Copyright 2020 Akretion France (http://www.akretion.com/)
+  Copyright 2020-2021 Akretion France (http://www.akretion.com/)
   @author Alexis de Lattre <alexis.delattre@akretion.com>
   License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 -->
@@ -11,14 +11,8 @@
         <field name="inherit_id" ref="account_cutoff_base.account_cutoff_form" />
         <field name="arch" type="xml">
             <field name="cutoff_date" position="after">
-                <label
-                    for="picking_interval_days"
-                    attrs="{'invisible': [('cutoff_type', 'not in', ('accrued_expense', 'accrued_revenue'))]}"
-                />
-                <div
-                    name="picking_interval_days"
-                    attrs="{'invisible': [('cutoff_type', 'not in', ('accrued_expense', 'accrued_revenue'))]}"
-                >
+                <label for="picking_interval_days" />
+                <div name="picking_interval_days">
                     <field name="picking_interval_days" class="oe_inline" /> days
                 </div>
             </field>

--- a/account_cutoff_accrual_picking/views/res_config_settings.xml
+++ b/account_cutoff_accrual_picking/views/res_config_settings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!--
-  Copyright 2013-2018 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
+  Copyright 2013-2021 Akretion France (http://www.akretion.com/)
+  @author: Alexis de Lattre <alexis.delattre@akretion.com>
   License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 -->
 <odoo>
@@ -12,13 +13,18 @@
             ref="account_cutoff_accrual_base.res_config_settings_view_form"
         />
         <field name="arch" type="xml">
-            <field name="accrual_taxes" position="after">
+                <div id="accrual_taxes" position="after">
+                        <div class="row" id="dft_cutoff_accrual_picking_interval_days">
                 <label
-                    for="dft_cutoff_accrual_picking_interval_days"
-                    class="col-lg-3 o_light_label"
-                />
-                <field name="dft_cutoff_accrual_picking_interval_days" /> days
-            </field>
+                        for="dft_cutoff_accrual_picking_interval_days"
+                        class="col-lg-4 o_light_label"
+                    />
+                <field
+                        name="dft_cutoff_accrual_picking_interval_days"
+                        class="col-lg-1"
+                    /> days
+                </div>
+            </div>
         </field>
     </record>
 </odoo>

--- a/account_cutoff_base/models/account_cutoff.py
+++ b/account_cutoff_base/models/account_cutoff.py
@@ -91,6 +91,9 @@ class AccountCutoff(models.Model):
         string="Source Entries",
         required=True,
         default="posted",
+        readonly=True,
+        states={"draft": [("readonly", False)]},
+        tracking=True,
     )
     move_id = fields.Many2one(
         "account.move", string="Cut-off Journal Entry", readonly=True, copy=False
@@ -105,7 +108,11 @@ class AccountCutoff(models.Model):
         "the Cut-off Account Move.",
     )
     move_partner = fields.Boolean(
-        string="Partner on Move Line", default=lambda self: self._default_move_partner()
+        string="Partner on Move Line",
+        default=lambda self: self._default_move_partner(),
+        readonly=True,
+        states={"draft": [("readonly", False)]},
+        tracking=True,
     )
     cutoff_account_id = fields.Many2one(
         comodel_name="account.account",

--- a/account_cutoff_base/models/company.py
+++ b/account_cutoff_base/models/company.py
@@ -13,3 +13,4 @@ class ResCompany(models.Model):
     default_cutoff_move_partner = fields.Boolean(
         string="Partner on Move Line by Default"
     )
+    post_cutoff_move = fields.Boolean(string="Post Cut-off Entry")

--- a/account_cutoff_base/models/res_config_settings.py
+++ b/account_cutoff_base/models/res_config_settings.py
@@ -11,8 +11,13 @@ class ResConfigSettings(models.TransientModel):
     # I can't name it default_cutoff_journal_id
     # because default_ is a special prefix
     dft_cutoff_journal_id = fields.Many2one(
-        related="company_id.default_cutoff_journal_id", readonly=False
+        related="company_id.default_cutoff_journal_id",
+        readonly=False,
+        domain="[('type', '=', 'general'), ('company_id', '=', company_id)]",
     )
     dft_cutoff_move_partner = fields.Boolean(
         related="company_id.default_cutoff_move_partner", readonly=False
+    )
+    post_cutoff_move = fields.Boolean(
+        related="company_id.post_cutoff_move", readonly=False
     )

--- a/account_cutoff_base/views/account_cutoff.xml
+++ b/account_cutoff_base/views/account_cutoff.xml
@@ -65,6 +65,7 @@
                                 name="cutoff_date"
                                 options="{'datepicker': {'warn_future': true}}"
                             />
+                            <field name="source_move_state" widget="radio" />
                             <field name="total_cutoff_amount" />
                             <field
                                 name="company_id"
@@ -175,6 +176,9 @@
                     invisible="'accrued' not in context.get('cutoff_type', '-')"
                 >
                     <field name="tax_line_ids" nolabel="1" />
+                </group>
+                <group name="notes" string="Notes">
+                    <field name="notes" nolabel="1" />
                 </group>
             </form>
         </field>

--- a/account_cutoff_base/views/res_config_settings.xml
+++ b/account_cutoff_base/views/res_config_settings.xml
@@ -16,24 +16,30 @@
                     <div class="col-xs-12 col-md-12 o_setting_box">
                         <div class="o_setting_left_pane" />
                         <div class="o_setting_right_pane">
-                            <div class="content-group">
-                                <div class="row mt16" name="dft_cutoff_journal_id">
+                                    <div class="row" id="dft_cutoff_move_partner">
                                     <label
-                                        for="dft_cutoff_move_partner"
-                                        class="col-lg-3 o_light_label"
-                                    />
+                                    for="dft_cutoff_move_partner"
+                                    class="col-lg-4 o_light_label"
+                                />
                                     <field name="dft_cutoff_move_partner" />
-                                    <label
-                                        for="dft_cutoff_journal_id"
-                                        class="col-lg-3 o_light_label"
-                                    />
-                                    <field
-                                        name="dft_cutoff_journal_id"
-                                        options="{'no_create_edit': True, 'no_open': True}"
-                                        domain="[('company_id', '=', company_id)]"
-                                    />
                                 </div>
-                            </div>
+                                    <div class="row" id="post_cutoff_move">
+                                    <label
+                                    for="post_cutoff_move"
+                                    class="col-lg-4 o_light_label"
+                                />
+                                    <field name="post_cutoff_move" />
+                                    </div>
+                                    <div class="row" id="dft_cutoff_journal_id">
+                                    <label
+                                    for="dft_cutoff_journal_id"
+                                    class="col-lg-4 o_light_label"
+                                />
+                                    <field
+                                    name="dft_cutoff_journal_id"
+                                    options="{'no_create_edit': True, 'no_open': True}"
+                                />
+                                    </div>
                         </div>
                     </div>
                 </div>

--- a/account_cutoff_prepaid/views/account_cutoff.xml
+++ b/account_cutoff_prepaid/views/account_cutoff.xml
@@ -45,7 +45,7 @@
                     attrs="{'invisible': ['|', '|', ('state', '!=', 'draft'), ('forecast', '=', False), ('cutoff_type', 'not in', ('prepaid_revenue', 'prepaid_expense'))]}"
                 />
             </button>
-            <field name="cutoff_date" position="before">
+            <field name="source_move_state" position="before">
                 <field
                     name="forecast"
                     attrs="{'invisible': [('forecast', '=', False)]}"
@@ -57,6 +57,11 @@
                 <field
                     name="end_date"
                     attrs="{'invisible': [('forecast', '=', False)], 'required': [('forecast', '=', True)]}"
+                />
+                <field
+                    name="source_journal_ids"
+                    widget="many2many_tags"
+                    domain="[('company_id', '=', company_id)]"
                 />
             </field>
             <field name="cutoff_date" position="attributes">
@@ -93,13 +98,6 @@
                     name="attrs"
                 >{'invisible': ['|', '|', ('line_ids', '=', False), ('state', '=', 'done'), ('forecast', '=', True)]}</attribute>
             </button>
-            <field name="cutoff_date" position="after">
-                <field
-                    name="source_journal_ids"
-                    widget="many2many_tags"
-                    domain="[('company_id', '=', company_id)]"
-                />
-            </field>
         </field>
     </record>
     <record id="account_cutoff_filter" model="ir.ui.view">

--- a/account_cutoff_prepaid/views/res_config_settings.xml
+++ b/account_cutoff_prepaid/views/res_config_settings.xml
@@ -12,26 +12,30 @@
             ref="account_cutoff_base.res_config_settings_view_form"
         />
         <field name="arch" type="xml">
-            <field name="dft_cutoff_journal_id" position="after">
+            <div id="dft_cutoff_journal_id" position="after">
+                <div class="row" id="dft_prepaid_revenue_account_id">
                 <label
-                    for="dft_prepaid_revenue_account_id"
-                    class="col-lg-3 o_light_label"
-                />
+                        for="dft_prepaid_revenue_account_id"
+                        class="col-lg-4 o_light_label"
+                    />
                 <field
-                    name="dft_prepaid_revenue_account_id"
-                    options="{'no_create_edit': True, 'no_open': True}"
-                    domain="[('company_id', '=', company_id)]"
-                />
+                        name="dft_prepaid_revenue_account_id"
+                        options="{'no_create_edit': True, 'no_open': True}"
+                        domain="[('company_id', '=', company_id)]"
+                    />
+        </div>
+        <div class="row" id="dft_prepaid_expense_account_id">
                 <label
-                    for="dft_prepaid_expense_account_id"
-                    class="col-lg-3 o_light_label"
-                />
+                        for="dft_prepaid_expense_account_id"
+                        class="col-lg-4 o_light_label"
+                    />
                 <field
-                    name="dft_prepaid_expense_account_id"
-                    options="{'no_create_edit': True, 'no_open': True}"
-                    domain="[('company_id', '=', company_id)]"
-                />
-            </field>
+                        name="dft_prepaid_expense_account_id"
+                        options="{'no_create_edit': True, 'no_open': True}"
+                        domain="[('company_id', '=', company_id)]"
+                    />
+            </div>
+            </div>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Also backport from 14 to 13 the field post_cutoff_move on res.company and the field source_move_state on account.cutoff