### PR TITLE
[FIX][14.0] account_fiscal_year_closing partial reconcile block recompute

### DIFF
--- a/account_fiscal_year_closing/models/account_fiscalyear_closing.py
+++ b/account_fiscal_year_closing/models/account_fiscalyear_closing.py
@@ -282,9 +282,7 @@ class AccountFiscalyearClosing(models.Model):
 
     def _moves_remove(self):
         for closing in self:
-            closing.mapped("move_ids.line_ids").filtered(
-                "reconciled"
-            ).remove_move_reconcile()
+            closing.mapped("move_ids.line_ids").remove_move_reconcile()
             closing.move_ids.button_cancel()
             closing.move_ids.unlink()
         return True


### PR DESCRIPTION
Partial reconcile aren't removed from current function and, if present, block closing recomputation.