### PR TITLE
[16.0] account_cutoff_base: simplify config for taxes

### DIFF
--- a/account_cutoff_accrual_subscription/models/account_cutoff.py
+++ b/account_cutoff_accrual_subscription/models/account_cutoff.py
@@ -15,7 +15,11 @@ class AccountCutoff(models.Model):
 
     def get_lines(self):
         res = super().get_lines()
-        if self.cutoff_type not in ["accrued_expense", "accrued_revenue"]:
+        type2subtype = {
+            "accrued_expense": "expense",
+            "accrued_revenue": "revenue",
+        }
+        if self.cutoff_type not in type2subtype:
             return res
 
         line_obj = self.env["account.cutoff.line"]
@@ -29,10 +33,6 @@ class AccountCutoff(models.Model):
         if not fy_start_date:
             raise UserError(_("Odoo cannot compute the fiscal year start date."))
 
-        type2subtype = {
-            "accrued_expense": "expense",
-            "accrued_revenue": "revenue",
-        }
         sub_type = type2subtype[self.cutoff_type]
         sign = sub_type == "revenue" and -1 or 1
         subs = sub_obj.search(

--- a/account_cutoff_accrual_subscription/models/account_cutoff_accrual_subscription.py
+++ b/account_cutoff_accrual_subscription/models/account_cutoff_accrual_subscription.py
@@ -66,10 +66,10 @@ class AccountCutoffAccrualSubscription(models.Model):
     )
     start_date = fields.Date(required=True)
     min_amount = fields.Monetary(
-        string="Minimum Expense Amount",
+        string="Minimum Amount",
         required=True,
         currency_field="company_currency_id",
-        help="Minimum expense amount without taxes over the period",
+        help="Minimum amount without taxes over the period",
     )
     provision_amount = fields.Monetary(
         string="Default Provision Amount", currency_field="company_currency_id"

--- a/account_cutoff_base/models/res_company.py
+++ b/account_cutoff_base/models/res_company.py
@@ -30,6 +30,16 @@ class ResCompany(models.Model):
         string="Default Account for Accrued Expenses",
         check_company=True,
     )
+    default_accrued_revenue_tax_account_id = fields.Many2one(
+        comodel_name="account.account",
+        string="Default Tax Account for Accrued Revenue",
+        check_company=True,
+    )
+    default_accrued_expense_tax_account_id = fields.Many2one(
+        comodel_name="account.account",
+        string="Default Tax Account for Accrued Expense",
+        check_company=True,
+    )
     default_prepaid_revenue_account_id = fields.Many2one(
         "account.account",
         string="Default Account for Prepaid Revenue",

--- a/account_cutoff_base/views/res_config_settings.xml
+++ b/account_cutoff_base/views/res_config_settings.xml
@@ -80,6 +80,34 @@
                                     options="{'no_create_edit': True, 'no_open': True}"
                                 />
                                 </div>
+                                <div
+                                class="row"
+                                id="dft_accrued_revenue_tax_account_id"
+                                attrs="{'invisible': [('accrual_taxes', '=', False)]}"
+                            >
+                                    <label
+                                    for="dft_accrued_revenue_tax_account_id"
+                                    class="col-md-5"
+                                />
+                                    <field
+                                    name="dft_accrued_revenue_tax_account_id"
+                                    options="{'no_create_edit': True, 'no_open': True}"
+                                />
+                                </div>
+                                <div
+                                class="row"
+                                id="dft_accrued_expense_tax_account_id"
+                                attrs="{'invisible': [('accrual_taxes', '=', False)]}"
+                            >
+                                    <label
+                                    for="dft_accrued_expense_tax_account_id"
+                                    class="col-md-5"
+                                />
+                                    <field
+                                    name="dft_accrued_expense_tax_account_id"
+                                    options="{'no_create_edit': True, 'no_open': True}"
+                                />
+                                </div>
                                 <div class="row" id="dft_prepaid_revenue_account_id">
                                     <label
                                     for="dft_prepaid_revenue_account_id"

--- a/account_cutoff_base/wizards/res_config_settings.py
+++ b/account_cutoff_base/wizards/res_config_settings.py
@@ -32,6 +32,16 @@ class ResConfigSettings(models.TransientModel):
         readonly=False,
         domain="[('deprecated', '=', False), ('company_id', '=', company_id)]",
     )
+    dft_accrued_revenue_tax_account_id = fields.Many2one(
+        related="company_id.default_accrued_revenue_tax_account_id",
+        readonly=False,
+        domain="[('deprecated', '=', False), ('company_id', '=', company_id)]",
+    )
+    dft_accrued_expense_tax_account_id = fields.Many2one(
+        related="company_id.default_accrued_expense_tax_account_id",
+        readonly=False,
+        domain="[('deprecated', '=', False), ('company_id', '=', company_id)]",
+    )
     dft_prepaid_revenue_account_id = fields.Many2one(
         related="company_id.default_prepaid_revenue_account_id",
         readonly=False,

--- a/account_cutoff_picking/models/res_company.py
+++ b/account_cutoff_picking/models/res_company.py
@@ -15,7 +15,7 @@ class ResCompany(models.Model):
         "N days before the cutoff date up to the cutoff date. "
         "N is the Analysis Interval. If you increase the analysis interval, "
         "Odoo will take more time to generate the cutoff lines.",
-        default=90,
+        default=30,
     )
 
     _sql_constraints = [

--- a/account_cutoff_picking/readme/DESCRIPTION.rst
+++ b/account_cutoff_picking/readme/DESCRIPTION.rst
@@ -2,7 +2,7 @@ This module generates expense/revenue accruals and prepaid expense/revenue based
 
 To understand the behavior of this module, let's take the example of an expense accrual. When you click on the button *Re-Generate Lines* of an *Expense Accrual*:
 
-1. Odoo will look for all incoming picking in Done state with a *Transfer Date* <= *Cut-off Date*. For performance reasons, by default, the incoming picking dated before *Cut-off Date* minus 90 days will not be taken into account (this limit is configurable via the field *Picking Analysis*). It will go to the stock moves of those pickings and see if they are linked to a purchase order line.
+1. Odoo will look for all incoming picking in Done state with a *Transfer Date* <= *Cut-off Date*. For performance reasons, by default, the incoming picking dated before *Cut-off Date* minus 30 days will not be taken into account (this limit is configurable via the field *Picking Analysis*). It will go to the stock moves of those pickings and see if they are linked to a purchase order line.
 2. Once this analysis is completed, Odoo has a list of purchase order lines to analyse for potential expense accrual.
 3. For each of these purchase order lines, Odoo will:
 
@@ -13,7 +13,7 @@ To understand the behavior of this module, let's take the example of an expense 
 
 Now, let's take the example of a prepaid expense. When you click on the button *Re-Generate Lines* of a *Prepaid Expense*:
 
-1. Odoo will look for all vendor bills dated before (or equal to) *Cut-off Date*. For performance reasons, by default, the vendor bills dated before *Cut-off Date* minus 90 days will not be taken into account (this limit is configurable via the field *Picking Analysis*). It will go to the invoice lines of those vendor bills and see if they are linked to a purchase order line.
+1. Odoo will look for all vendor bills dated before (or equal to) *Cut-off Date*. For performance reasons, by default, the vendor bills dated before *Cut-off Date* minus 30 days will not be taken into account (this limit is configurable via the field *Picking Analysis*). It will go to the invoice lines of those vendor bills and see if they are linked to a purchase order line.
 2. Once this analysis is completed, Odoo has a list of purchase order lines to analyse for potential prepaid expense.
 3. For each of these purchase order lines, Odoo will:
 


### PR DESCRIPTION
For all countries where the provision account for taxes is the same for all taxes, you can now configure the 2 provision accounts for taxes on the accounting configuration page.
This commit also fixes a bug in the generation of the move when you have a default tax on the revenue/expense account.