### PR TITLE
[IMP][14.0] account_fiscal_year_closing do not split by partner account of type not in receivable or payable

### DIFF
--- a/account_fiscal_year_closing/models/account_fiscalyear_closing.py
+++ b/account_fiscal_year_closing/models/account_fiscalyear_closing.py
@@ -452,13 +452,19 @@ class AccountFiscalyearClosingConfig(models.Model):
             for account in src_accounts:
                 closing_type = self.closing_type_get(account)
                 balance = False
-                if closing_type == "balance":
+                if closing_type == "balance" or (
+                    closing_type == "unreconciled"
+                    and account.internal_type not in ["receivable", "payable"]
+                ):
                     # Get all lines
                     lines = account_map.account_lines_get(account)
                     balance, move_line = account_map.move_line_prepare(account, lines)
                     if move_line:
                         move_lines.append(move_line)
-                elif closing_type == "unreconciled":
+                elif closing_type == "unreconciled" and account.internal_type in [
+                    "receivable",
+                    "payable",
+                ]:
                     # Get credit and debit grouping by partner
                     partners = account_map.account_partners_get(account)
                     for partner in partners:


### PR DESCRIPTION
The current method create an account.move.line for every partner found in every account.account, which is unuseful (account like assets or bank or every other different of a credit or debit).

With this fix, only the account of type 'payable' or 'receivable' are splitted by partner.