### PR TITLE
[16.0][FIX] account_multicurrency_revaluation: avoid error in query

### DIFF
--- a/account_multicurrency_revaluation/model/account.py
+++ b/account_multicurrency_revaluation/model/account.py
@@ -152,7 +152,7 @@ class AccountAccount(models.Model):
                 ("parent_state", "!=", "cancel"),
             ]
         )
-        self._apply_ir_rules(query)
+        self.env["account.move.line"]._apply_ir_rules(query)
         tables, where_clause, where_clause_params = query.get_sql()
         mapping = [
             ('"account_move_line".', "aml."),


### PR DESCRIPTION
```yml
File "/opt/odoo/addons/web/controllers/dataset.py", line 46, in call_button
action = self._call_kw(model, method, args, kwargs)
File "/opt/odoo/addons/web/controllers/dataset.py", line 33, in _call_kw
return call_kw(request.env[model], method, args, kwargs)
File "/opt/odoo/odoo/api.py", line 466, in call_kw
result = _call_kw_multi(method, model, args, kwargs)
File "/opt/odoo/odoo/api.py", line 453, in _call_kw_multi
result = method(recs, *args, **kwargs)
File "/mnt/data/odoo-addons-dir/account_multicurrency_revaluation/wizard/wizard_currency_revaluation.py", line 330, in revaluate_currency
revaluations = account_ids.compute_revaluations(
File "/mnt/data/odoo-addons-dir/account_multicurrency_revaluation/model/account.py", line 251, in compute_revaluations
self.env.cr.execute(query, params)
File "/opt/odoo/odoo/sql_db.py", line 321, in execute
res = self._obj.execute(query, params)
psycopg2.errors.UndefinedTable: invalid reference to FROM-clause entry for table "account_account"
LINE 43: AND ("account_account"."company_id" IS NULL OR ...
^
HINT: Perhaps you meant to reference the table alias "acc".
```