### PR TITLE
[16.0][FIX] oca: account_multicurrency_revaluation

### DIFF
--- a/account_multicurrency_revaluation/wizard/wizard_reverse_currency_revaluation.py
+++ b/account_multicurrency_revaluation/wizard/wizard_reverse_currency_revaluation.py
@@ -74,7 +74,7 @@ class WizardCurrencyRevaluation(models.TransientModel):
         created_entries.write(vals)
         if self.journal_id.company_id.auto_post_entries:
             for entry in created_entries:
-                entry.post()
+                entry.action_post()
         # Mark entries reversed as not to be reversed anymore
         entries.write({"revaluation_to_reverse": False})
         if created_entries:


### PR DESCRIPTION
Fix for the following error:
```
Traceback (most recent call last):
  File "/opt/odoo/odoo/http.py", line 1633, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/opt/odoo/odoo/service/model.py", line 133, in retrying
    result = func()
  File "/opt/odoo/odoo/http.py", line 1660, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/opt/odoo/odoo/http.py", line 1864, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/opt/odoo/odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "/opt/odoo/odoo/http.py", line 697, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/opt/odoo/addons/web/controllers/dataset.py", line 46, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "/opt/odoo/addons/web/controllers/dataset.py", line 33, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/opt/odoo/odoo/api.py", line 468, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/opt/odoo/odoo/api.py", line 453, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/mnt/data/odoo-addons-dir/account_multicurrency_revaluation/wizard/wizard_reverse_currency_revaluation.py", line 77, in reverse_revaluate_currency
    entry.post()
AttributeError: 'account.move' object has no attribute 'post'

The above server error caused the following client error:
RPC_ERROR: Odoo Server Error
    at makeErrorFromResponse (http://oca-account-closing-16-0-109aa6d5a5ed.runboat.odoo-community.org/web/assets/448-ffdd845/web.assets_backend.min.js:992:163)
    at XMLHttpRequest.<anonymous> (http://oca-account-closing-16-0-109aa6d5a5ed.runboat.odoo-community.org/web/assets/448-ffdd845/web.assets_backend.min.js:1000:13)
```