### PR TITLE
[14.0] [FIX] account_fiscal_year_closing - create/write

### DIFF
--- a/account_fiscal_year_closing/models/account_fiscalyear_closing.py
+++ b/account_fiscal_year_closing/models/account_fiscalyear_closing.py
@@ -553,13 +553,13 @@ class AccountFiscalyearClosingMapping(models.Model):
 
     @api.model
     def create(self, vals):
-        if "dest_account_id" in vals:
+        if "dest_account_id" in vals and type(vals["dest_account_id"]) == list:
             vals["dest_account_id"] = vals["dest_account_id"][0]
         res = super(AccountFiscalyearClosingMapping, self).create(vals)
         return res
 
     def write(self, vals):
-        if "dest_account_id" in vals:
+        if "dest_account_id" in vals and type(vals["dest_account_id"]) == list:
             vals["dest_account_id"] = vals["dest_account_id"][0]
         res = super(AccountFiscalyearClosingMapping, self).write(vals)
         return res


### PR DESCRIPTION
When creating new fiscal year closing with an account mapping (with destination account) in moves configuration, an issue is raised at save (Issue https://github.com/OCA/account-closing/issues/280).

But when coming from a template (selecting template on screen), Mapping data are used as an Array instead instead of simple id (due to many inside another many). 

The current code manage only case from template.

This PR take into account this particularity (and mangage other way), check the type before taking the id of the array.