### PR TITLE
[16.0][FIX] account_cutoff_picking: is not an app 

### DIFF
--- a/account_cutoff_picking/__manifest__.py
+++ b/account_cutoff_picking/__manifest__.py
@@ -19,5 +19,5 @@
         "images/accrued_expense_done.jpg",
     ],
     "installable": True,
-    "application": True,
+    "application": False,
 }


### PR DESCRIPTION
Supersedes https://github.com/OCA/account-closing/pull/246