### PR TITLE
[17.0][PORT] account_invoice_start_end_dates: add start/end dates in tree view of move lines

### DIFF
--- a/account_invoice_start_end_dates/__manifest__.py
+++ b/account_invoice_start_end_dates/__manifest__.py
@@ -13,7 +13,11 @@
     "maintainers": ["alexis-via"],
     "website": "https://github.com/OCA/account-closing",
     "depends": ["account"],
-    "data": ["views/account_move.xml", "views/product_template.xml"],
+    "data": [
+        "views/account_move.xml",
+        "views/account_move_line.xml",
+        "views/product_template.xml",
+    ],
     "demo": ["demo/product_demo.xml"],
     "installable": True,
 }

--- a/account_invoice_start_end_dates/views/account_move.xml
+++ b/account_invoice_start_end_dates/views/account_move.xml
@@ -1,34 +1,10 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!--
-  Copyright 2013-2021 Akretion France (http://www.akretion.com/)
+  Copyright 2013-2022 Akretion France (http://www.akretion.com/)
   @author: Alexis de Lattre <alexis.delattre@akretion.com>
   License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 -->
 <odoo>
-    <record id="view_move_line_form" model="ir.ui.view">
-        <field name="name">start_end_dates.view_move_line_form</field>
-        <field name="model">account.move.line</field>
-        <field name="inherit_id" ref="account.view_move_line_form" />
-        <field name="arch" type="xml">
-            <field name="date_maturity" position="after">
-                <field name="must_have_dates" invisible="1" />
-                <field name="start_date" required="must_have_dates" />
-                <field name="end_date" required="must_have_dates" />
-            </field>
-        </field>
-    </record>
-    <record id="view_move_line_tree" model="ir.ui.view">
-        <field name="name">start_end_dates.view_move_line_tree</field>
-        <field name="model">account.move.line</field>
-        <field name="inherit_id" ref="account.view_move_line_tree" />
-        <field name="arch" type="xml">
-            <field name="date_maturity" position="after">
-                <field name="must_have_dates" column_invisible="1" />
-                <field name="start_date" optional="hide" />
-                <field name="end_date" optional="hide" />
-            </field>
-        </field>
-    </record>
     <record id="view_move_form" model="ir.ui.view">
         <field name="name">start_end_dates.view_move_form</field>
         <field name="model">account.move</field>

--- a/account_invoice_start_end_dates/views/account_move_line.xml
+++ b/account_invoice_start_end_dates/views/account_move_line.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Copyright 2013-2022 Akretion France (http://www.akretion.com/)
+  @author: Alexis de Lattre <alexis.delattre@akretion.com>
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+    <record id="view_move_line_form" model="ir.ui.view">
+        <field name="name">start_end_dates.view_move_line_form</field>
+        <field name="model">account.move.line</field>
+        <field name="inherit_id" ref="account.view_move_line_form" />
+        <field name="arch" type="xml">
+            <field name="date_maturity" position="after">
+                <field name="must_have_dates" invisible="1" />
+                <field name="start_date" required="must_have_dates" />
+                <field name="end_date" required="must_have_dates" />
+            </field>
+        </field>
+    </record>
+    <record id="view_move_line_tree" model="ir.ui.view">
+        <field name="name">start_end_dates.view_move_line_tree</field>
+        <field name="model">account.move.line</field>
+        <field name="inherit_id" ref="account.view_move_line_tree" />
+        <field name="arch" type="xml">
+            <field name="date_maturity" position="after">
+                <field name="must_have_dates" column_invisible="1" />
+                <field name="start_date" optional="hide" />
+                <field name="end_date" optional="hide" />
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Ported this from 14.0 to 17.0: 
- [https://github.com/OCA/account-closing/pull/195](https://github.com/OCA/account-closing/pull/195)

