### PR TITLE
[14.0][FIX] account_move_cutoff: while using full refund wizard

### DIFF
--- a/account_move_cutoff/models/account_move.py
+++ b/account_move_cutoff/models/account_move.py
@@ -41,8 +41,8 @@ class AccountMove(models.Model):
         self.cutoff_entry_ids.with_context(force_delete=True).unlink()
         return res
 
-    def action_post(self):
-        result = super().action_post()
+    def _post(self, *args, **kwargs):
+        result = super()._post(*args, **kwargs)
         for move, lines in self._get_deferrable_lines():
             move._create_cutoff_entries(lines)
 

--- a/account_move_cutoff/tests/test_account_invoice_cutoff.py
+++ b/account_move_cutoff/tests/test_account_invoice_cutoff.py
@@ -538,3 +538,15 @@ class TestInvoiceCutoff(CommonAccountInvoiceCutoffCase):
             255.0,
             2,
         )
+
+    def test_reverse_moves_reverse_deffered(self):
+
+        with freeze_time("2023-01-15"):
+            self.invoice.action_post()
+            self.assertTrue(len(self.invoice.cutoff_entry_ids) > 0)
+            refund = self.invoice._reverse_moves(cancel=True)
+
+        self.assertEqual(refund.state, "posted")
+        self.assertEqual(
+            len(self.invoice.cutoff_entry_ids), len(refund.cutoff_entry_ids)
+        )


### PR DESCRIPTION
action_post is not called better to overload _post on account.move model