### PR TITLE
[FIX] account_cutoff_start_end_dates: Only expense cutoffs retrieve expense lines

### DIFF
--- a/account_cutoff_base/README.rst
+++ b/account_cutoff_base/README.rst
@@ -86,6 +86,9 @@ Contributors
 * Pedro M. Baeza <pedro.baeza@gmail.com>
 * Jeroen Evens <jeroen.evenss@dynapps.be>
 * Jim Hoefnagels <jim.hoefnagels@dynapps.be>
+* `Aion Tech <https://aiontech.company/>`_:
+
+  * Simone Rubino <simone.rubino@aion-tech.it>
 
 Maintainers
 ~~~~~~~~~~~

--- a/account_cutoff_base/readme/CONTRIBUTORS.rst
+++ b/account_cutoff_base/readme/CONTRIBUTORS.rst
@@ -5,3 +5,6 @@
 * Pedro M. Baeza <pedro.baeza@gmail.com>
 * Jeroen Evens <jeroen.evenss@dynapps.be>
 * Jim Hoefnagels <jim.hoefnagels@dynapps.be>
+* `Aion Tech <https://aiontech.company/>`_:
+
+  * Simone Rubino <simone.rubino@aion-tech.it>

--- a/account_cutoff_base/static/description/index.html
+++ b/account_cutoff_base/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -432,12 +432,18 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Pedro M. Baeza &lt;<a class="reference external" href="mailto:pedro.baeza&#64;gmail.com">pedro.baeza&#64;gmail.com</a>&gt;</li>
 <li>Jeroen Evens &lt;<a class="reference external" href="mailto:jeroen.evenss&#64;dynapps.be">jeroen.evenss&#64;dynapps.be</a>&gt;</li>
 <li>Jim Hoefnagels &lt;<a class="reference external" href="mailto:jim.hoefnagels&#64;dynapps.be">jim.hoefnagels&#64;dynapps.be</a>&gt;</li>
+<li><a class="reference external" href="https://aiontech.company/">Aion Tech</a>:<ul>
+<li>Simone Rubino &lt;<a class="reference external" href="mailto:simone.rubino&#64;aion-tech.it">simone.rubino&#64;aion-tech.it</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/account_cutoff_start_end_dates/models/account_cutoff.py
+++ b/account_cutoff_start_end_dates/models/account_cutoff.py
@@ -1,5 +1,6 @@
 # Copyright 2016-2021 Akretion France
 # @author: Alexis de Lattre <alexis.delattre@akretion.com>
+# Copyright 2024 Simone Rubino - Aion Tech
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import _, api, fields, models
@@ -188,6 +189,15 @@ class AccountCutoff(models.Model):
             domain.append(("parent_state", "=", "posted"))
         else:
             domain.append(("parent_state", "in", ("draft", "posted")))
+
+        if self.cutoff_type in ["prepaid_expense", "accrued_expense"]:
+            domain += [
+                ("account_internal_group", "=", "expense"),
+            ]
+        elif self.cutoff_type in ["prepaid_revenue", "accrued_revenue"]:
+            domain += [
+                ("account_internal_group", "=", "income"),
+            ]
 
         if self.cutoff_type in ["prepaid_expense", "prepaid_revenue"]:
             if self.forecast:

--- a/account_cutoff_start_end_dates/tests/test_account_cutoff_prepaid.py
+++ b/account_cutoff_start_end_dates/tests/test_account_cutoff_prepaid.py
@@ -1,13 +1,15 @@
 # Copyright 2014 ACSONE SA/NV (http://acsone.eu)
 # @author Stéphane Bidoul <stephane.bidoul@acsone.eu>
 # Copyright 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
+# Copyright 2024 Simone Rubino - Aion Tech
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 
 import time
+from datetime import date
 
 from odoo import fields
-from odoo.tests.common import SavepointCase
+from odoo.tests.common import Form, SavepointCase
 
 
 class TestCutoffPrepaid(SavepointCase):
@@ -104,12 +106,12 @@ class TestCutoffPrepaid(SavepointCase):
         self.assertEqual(amount, invoice.amount_untaxed)
         return invoice
 
-    def _create_cutoff(self, date):
+    def _create_cutoff(self, date, cutoff_type="prepaid_expense"):
         cutoff = self.cutoff_model.create(
             {
                 "company_id": self.env.ref("base.main_company").id,
                 "cutoff_date": self._date(date),
-                "cutoff_type": "prepaid_revenue",
+                "cutoff_type": cutoff_type,
                 "cutoff_journal_id": self.cutoff_journal.id,
                 "cutoff_account_id": self.account_cutoff.id,
                 "source_journal_ids": [(6, 0, [self.purchase_journal.id])],
@@ -151,3 +153,70 @@ class TestCutoffPrepaid(SavepointCase):
         # two invoices, but two lines (because the two cutoff lines
         # have been grouped into one line plus one counterpart)
         self.assertEqual(len(cutoff.move_id.line_ids), 2)
+
+    def test_general_entry_prepaid_expense_cutoff_account(self):
+        """
+        Create an account move on a general journal for an expense account,
+        only the expense cutoff should retrieve its line."""
+        # Arrange
+        company = self.env.ref("base.main_company")
+        bank_account = self.env["account.account"].search(
+            [
+                ("internal_type", "=", "liquidity"),
+                ("company_id", "=", company.id),
+            ],
+            limit=1,
+        )
+        expense_account = self.account_expense
+        misc_journal = self.cutoff_journal
+        month_day_move_date = "10-31"
+        move_date = fields.Date.from_string(self._date(month_day_move_date))
+
+        move_form = Form(self.env["account.move"])
+        move_form.date = move_date
+        move_form.journal_id = misc_journal
+        with move_form.line_ids.new() as line:
+            line.account_id = expense_account
+            line.debit = 1000
+            line.start_date = date(move_date.year + 1, 1, 1)
+            line.end_date = date(move_date.year + 1, 12, 31)
+        with move_form.line_ids.new() as line:
+            line.account_id = bank_account
+            line.credit = 1000
+        move = move_form.save()
+        move.action_post()
+
+        prepaid_expense_cutoff = self._create_cutoff(
+            month_day_move_date,
+            cutoff_type="prepaid_expense",
+        )
+        prepaid_expense_cutoff.source_journal_ids = misc_journal
+
+        prepaid_revenue_cutoff = self._create_cutoff(
+            month_day_move_date,
+            cutoff_type="prepaid_revenue",
+        )
+        prepaid_revenue_cutoff.source_journal_ids = misc_journal
+
+        # pre-condition
+        expense_move_line = move.line_ids.filtered(
+            lambda line: line.account_id.internal_group == "expense"
+        )
+        self.assertTrue(expense_move_line)
+        self.assertEqual(move.journal_id.type, "general")
+
+        self.assertEqual(prepaid_expense_cutoff.cutoff_type, "prepaid_expense")
+        self.assertEqual(prepaid_expense_cutoff.source_journal_ids.type, "general")
+
+        self.assertEqual(prepaid_revenue_cutoff.cutoff_type, "prepaid_revenue")
+        self.assertEqual(prepaid_revenue_cutoff.source_journal_ids.type, "general")
+
+        # Act
+        prepaid_expense_cutoff.get_lines()
+        prepaid_revenue_cutoff.get_lines()
+
+        # Assert
+        self.assertEqual(
+            prepaid_expense_cutoff.line_ids.origin_move_line_id, expense_move_line
+        )
+        self.assertFalse(prepaid_revenue_cutoff.line_ids)


### PR DESCRIPTION
**Steps**:

1. create a journal entry in the Miscellaneous journal;
2. in the entry, add a debit line for an expense account (with start/end dates), and a credit bank line for balancing;
3. confirm the entry;
4. create an accrual expense cutoff and an accrual revenue cutoff, both having only the Miscellaneous journal as source journal;
5. generate the lines for both cutoffs.

**Expected behavior**:
Only the accrual expense cutoff generates a line.

**Actual behavior**:
Both the accrual cutoffs generate a line.
