### PR TITLE
[FIX] account_cutoff_start_end_dates: Only expense cutoffs retrieve expense lines

### DIFF
--- a/account_cutoff_start_end_dates/README.rst
+++ b/account_cutoff_start_end_dates/README.rst
@@ -99,6 +99,9 @@ Contributors
 * Jim Hoefnagels <jim.hoefnagels@dynapps.be>
 * `Trobz <https://trobz.com>`_:
     * Dzung Tran <dungtd@trobz.com>
+* `Aion Tech <https://aiontech.company/>`_:
+  * Federico Medici <federico.medici@aion-tech.it>
+  * Simone Rubino <simone.rubino@aion-tech.it>
 
 Other credits
 ~~~~~~~~~~~~~

--- a/account_cutoff_start_end_dates/__manifest__.py
+++ b/account_cutoff_start_end_dates/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     "name": "Account Cut-off Start End Dates",
-    "version": "16.0.1.1.0",
+    "version": "16.0.1.1.2",
     "category": "Accounting & Finance",
     "license": "AGPL-3",
     "summary": "Cutoffs based on start/end dates",

--- a/account_cutoff_start_end_dates/models/account_cutoff.py
+++ b/account_cutoff_start_end_dates/models/account_cutoff.py
@@ -1,5 +1,6 @@
 # Copyright 2016-2022 Akretion France
 # @author: Alexis de Lattre <alexis.delattre@akretion.com>
+# Copyright 2025 Federico Medici, Simone Rubino - Aion Tech
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import _, api, fields, models
@@ -185,6 +186,15 @@ class AccountCutoff(models.Model):
             domain.append(("parent_state", "=", "posted"))
         else:
             domain.append(("parent_state", "in", ("draft", "posted")))
+
+        if self.cutoff_type in ["prepaid_expense", "accrued_expense"]:
+            domain += [
+                ("account_internal_group", "=", "expense"),
+            ]
+        elif self.cutoff_type in ["prepaid_revenue", "accrued_revenue"]:
+            domain += [
+                ("account_internal_group", "=", "income"),
+            ]
 
         if self.cutoff_type in ["prepaid_expense", "prepaid_revenue"]:
             if self.state == "forecast":

--- a/account_cutoff_start_end_dates/readme/CONTRIBUTORS.rst
+++ b/account_cutoff_start_end_dates/readme/CONTRIBUTORS.rst
@@ -3,3 +3,6 @@
 * Jim Hoefnagels <jim.hoefnagels@dynapps.be>
 * `Trobz <https://trobz.com>`_:
     * Dzung Tran <dungtd@trobz.com>
+* `Aion Tech <https://aiontech.company/>`_:
+  * Federico Medici <federico.medici@aion-tech.it>
+  * Simone Rubino <simone.rubino@aion-tech.it>

--- a/account_cutoff_start_end_dates/static/description/index.html
+++ b/account_cutoff_start_end_dates/static/description/index.html
@@ -446,6 +446,11 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <dd><ul class="first last">
 <li>Dzung Tran &lt;<a class="reference external" href="mailto:dungtd&#64;trobz.com">dungtd&#64;trobz.com</a>&gt;</li>
 </ul>
+<li><a class="reference external" href="https://aiontech.company/">Aion Tech</a>:<ul>
+<li>Federico Medici &lt;<a class="reference external" href="mailto:federico.medici&#64;aion-tech.it">federico.medici&#64;aion-tech.it</a>&gt;</li>
+<li>Simone Rubino &lt;<a class="reference external" href="mailto:simone.rubino&#64;aion-tech.it">simone.rubino&#64;aion-tech.it</a>&gt;</li>
+</ul>
+</li>
 </dd>
 </dl>
 </li>


### PR DESCRIPTION
Repost the PR https://github.com/OCA/account-closing/pull/308since the problem also occurs in version 16