### PR TITLE
[18.0] dotfiles update needs manual intervention

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.27
+_commit: v1.29
 _src_path: git+https://github.com/OCA/oca-addons-repo-template
 additional_ruff_rules: []
 ci: GitHub

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,13 +13,13 @@ jobs:
   pre-commit:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: Get python version
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
           key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Detect unreleased dependencies
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: |
           for reqfile in requirements.txt test-requirements.txt ; do
               if [ -f ${reqfile} ] ; then
@@ -52,7 +52,7 @@ jobs:
     env:
       OCA_ENABLE_CHECKLOG_ODOO: "1"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Install addons and dependencies

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -10,6 +10,7 @@ extend-select = [
     "I",  # isort
     "UP",  # pyupgrade
 ]
+extend-safe-fixes = ["UP008"]
 exclude = ["setup/*"]
 
 [format]

--- a/checklog-odoo.cfg
+++ b/checklog-odoo.cfg
@@ -1,0 +1,3 @@
+[checklog-odoo]
+ignore=
+    WARNING.* 0 failed, 0 error\(s\).*


### PR DESCRIPTION
Dear maintainer,

After updating the dotfiles, `pre-commit run -a`
fails in a manner that cannot be resolved automatically.

Can you please have a look, fix and merge?

Thanks,
