### PR TITLE
[16.0][IMP] account_invoice_start_end_dates: position in tree view

### DIFF
--- a/account_invoice_start_end_dates/views/account_move.xml
+++ b/account_invoice_start_end_dates/views/account_move.xml
@@ -28,7 +28,7 @@
         <field name="model">account.move.line</field>
         <field name="inherit_id" ref="account.view_move_line_tree" />
         <field name="arch" type="xml">
-            <field name="date_maturity" position="after">
+            <field name="name" position="after">
                 <field name="must_have_dates" invisible="1" />
                 <field name="start_date" optional="hide" />
                 <field name="end_date" optional="hide" />


### PR DESCRIPTION
Move position of start_date and end_date in journal items tree view, to avoid having start_date and end_date in between debit/credit and balance.

BEFORE
![before_start_dates](https://github.com/user-attachments/assets/de345e93-a7a9-44fd-b2d4-46af409c61ea)

AFTER
![after_start_date_position](https://github.com/user-attachments/assets/2a8b21c7-fd9d-46bf-8be8-a64859d4ee4e)
