### PR TITLE
[IMP] Move the constraint on uniqueness for cutoff date at line level using a configuration

### DIFF
--- a/account_cutoff_base/migrations/16.0.1.5.1/post-migrate.py
+++ b/account_cutoff_base/migrations/16.0.1.5.1/post-migrate.py
@@ -1,0 +1,19 @@
+# Copyright 2024 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import logging
+
+import odoo
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    _logger.info("Remove constraint on account cutoff")
+    odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})
+
+    cr.execute(
+        """
+        ALTER TABLE account_cutoff
+        DROP CONSTRAINT IF EXISTS account_cutoff_date_type_company_uniq
+    """
+    )

--- a/account_cutoff_base/models/account_cutoff.py
+++ b/account_cutoff_base/models/account_cutoff.py
@@ -203,14 +203,6 @@ class AccountCutoff(models.Model):
         "the state is set to 'Done' and the fields become read-only.",
     )
 
-    _sql_constraints = [
-        (
-            "date_type_company_uniq",
-            "unique(cutoff_date, company_id, cutoff_type)",
-            _("A cutoff of the same type already exists with this cut-off date !"),
-        )
-    ]
-
     def name_get(self):
         res = []
         type2label = self.cutoff_type_label_map

--- a/account_cutoff_base/models/account_cutoff_line.py
+++ b/account_cutoff_base/models/account_cutoff_line.py
@@ -2,7 +2,9 @@
 # @author: Alexis de Lattre <alexis.delattre@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+from odoo.tools import str2bool
 
 
 class AccountCutoffLine(models.Model):
@@ -12,7 +14,8 @@ class AccountCutoffLine(models.Model):
     _description = "Account Cut-off Line"
 
     parent_id = fields.Many2one("account.cutoff", string="Cut-off", ondelete="cascade")
-    cutoff_type = fields.Selection(related="parent_id.cutoff_type")
+    cutoff_type = fields.Selection(related="parent_id.cutoff_type", store=True)
+    cutoff_date = fields.Date(related="parent_id.cutoff_date", store=True)
     company_id = fields.Many2one(
         "res.company", related="parent_id.company_id", store=True
     )
@@ -83,3 +86,54 @@ class AccountCutoffLine(models.Model):
         readonly=True,
     )
     notes = fields.Text()
+
+    def _is_check_cutoff_date_on_lines_enabled(self):
+        return str2bool(
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("account_cutoff_base.check_cutoff_date_on_lines_enabled")
+        )
+
+    @api.constrains("cutoff_date", "company_id", "cutoff_type", "origin_move_line_id")
+    def _check_unique_cutoff_date_on_lines(self):
+        check_cutoff_date_on_lines_enabled = (
+            self._is_check_cutoff_date_on_lines_enabled()
+        )
+        if check_cutoff_date_on_lines_enabled:
+            read_group = self.env["account.cutoff.line"].read_group(
+                domain=[("id", "in", self.ids), ("origin_move_line_id", "!=", False)],
+                fields=[
+                    "cutoff_date",
+                    "company_id",
+                    "cutoff_type",
+                    "origin_move_line_id",
+                ],
+                groupby=[
+                    "cutoff_date",
+                    "company_id",
+                    "cutoff_type",
+                    "origin_move_line_id",
+                ],
+                lazy=False,
+            )
+
+            if any(r["__count"] > 1 for r in read_group):
+                raise UserError(
+                    _(
+                        "A cutoff line of the same type already exists with this cut-off date !"
+                    )
+                )
+        else:
+            read_group = self.env["account.cutoff"].read_group(
+                domain=[("id", "in", self.ids)],
+                fields=["cutoff_date", "company_id", "cutoff_type"],
+                groupby=["cutoff_date", "company_id", "cutoff_type"],
+                lazy=False,
+            )
+
+            if any(r["__count"] > 1 for r in read_group):
+                raise UserError(
+                    _(
+                        "A cutoff of the same type already exists with this cut-off date !"
+                    )
+                )

--- a/account_cutoff_base/views/res_config_settings.xml
+++ b/account_cutoff_base/views/res_config_settings.xml
@@ -156,6 +156,17 @@
                                 </div>
                             </div>
                     </div>
+                    <div class="col-12 col-lg-12 o_setting_box" id="cutoff_on_lines">
+                        <div class="o_setting_left_pane">
+                            <field name="check_cutoff_date_on_lines_enabled" />
+                        </div>
+                        <div class="o_setting_right_pane">
+                            <label for="check_cutoff_date_on_lines_enabled" />
+                            <div class="text-muted">
+                               Check this box to check cutoff date unicity on lines.
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </xpath>
         </field>

--- a/account_cutoff_base/wizards/res_config_settings.py
+++ b/account_cutoff_base/wizards/res_config_settings.py
@@ -62,3 +62,12 @@ class ResConfigSettings(models.TransientModel):
         readonly=False,
         domain="[('deprecated', '=', False), ('company_id', '=', company_id)]",
     )
+
+    check_cutoff_date_on_lines_enabled = fields.Boolean(
+        string="Cutoff dates unicity on lines",
+        help=(
+            "Check this if you want to check unicity of cutoff "
+            "dates on lines instead of on the whole move"
+        ),
+        config_parameter="account_cutoff_base.check_cutoff_date_on_lines_enabled",
+    )

--- a/account_cutoff_start_end_dates/models/__init__.py
+++ b/account_cutoff_start_end_dates/models/__init__.py
@@ -1,2 +1,3 @@
 from . import account_cutoff
 from . import account_cutoff_line
+from . import account_move_line

--- a/account_cutoff_start_end_dates/models/account_cutoff.py
+++ b/account_cutoff_start_end_dates/models/account_cutoff.py
@@ -4,6 +4,7 @@
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
+from odoo.tools import str2bool
 
 
 class AccountCutoff(models.Model):
@@ -91,6 +92,7 @@ class AccountCutoff(models.Model):
             "name": aml.name,
             "start_date": aml.start_date,
             "end_date": aml.end_date,
+            "cutoff_date": self.cutoff_date,
             "account_id": aml.account_id.id,
             "cutoff_account_id": cutoff_account_id,
             "analytic_distribution": aml.analytic_distribution,
@@ -209,8 +211,19 @@ class AccountCutoff(models.Model):
                 ("start_date", "<=", self.cutoff_date),
                 ("date", ">", self.cutoff_date),
             ]
-        amls = aml_obj.search(domain)
-        for aml in amls:
-            line_obj.create(self._prepare_date_cutoff_line(aml, mapping))
 
+        amls = aml_obj.search(domain)
+        check_date_on_lines_enabled = str2bool(
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("account_cutoff_base.check_cutoff_date_on_lines_enabled")
+        )
+        for aml in amls:
+            if (
+                check_date_on_lines_enabled
+                and self.cutoff_date in aml.cutoff_line_ids.mapped("cutoff_date")
+            ):
+                # cutoff line already exists for this date
+                continue
+            line_obj.create(self._prepare_date_cutoff_line(aml, mapping))
         return res

--- a/account_cutoff_start_end_dates/models/account_move_line.py
+++ b/account_cutoff_start_end_dates/models/account_move_line.py
@@ -1,0 +1,15 @@
+# Copyright 2024 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class AccountMoveLine(models.Model):
+
+    _inherit = "account.move.line"
+    cutoff_line_ids = fields.One2many(
+        "account.cutoff.line",
+        inverse_name="origin_move_line_id",
+        string="Related cutoff line",
+        readonly=True,
+    )

--- a/account_cutoff_start_end_dates/tests/test_account_cutoff_prepaid.py
+++ b/account_cutoff_start_end_dates/tests/test_account_cutoff_prepaid.py
@@ -129,6 +129,18 @@ class TestCutoffPrepaid(TransactionCase):
         cutoff = self._create_cutoff("01-31")
         cutoff.get_lines()
         self.assertEqual(amount, cutoff.total_cutoff_amount)
+        # cutoff at the same date as the previous one : no new line created
+        # activate the config parameter to test this
+        self.env["ir.config_parameter"].sudo().set_param(
+            "account_cutoff_base.check_cutoff_date_on_lines_enabled", True
+        )
+        cutoff = self._create_cutoff("01-31")
+        cutoff.get_lines()
+        self.assertEqual(0, cutoff.total_cutoff_amount)
+        # deactivate the config parameter
+        self.env["ir.config_parameter"].sudo().set_param(
+            "account_cutoff_base.check_cutoff_date_on_lines_enabled", False
+        )
 
     def tests_1(self):
         """generate move, and test move lines grouping"""


### PR DESCRIPTION
+ Add the possibility to create several cutoff with the same date

If the box is not checked in configurations,  the uniqueness is checked at the cutoff level (as previously done). If we need to create several cutoff at the same date for different journals/accounts, we can check the box and the check will be done at the cutoff line level.

Business case can be :

- One user (A) creates a cutoff for some account moves. Another user (B) creates other moves, then wants to see those moves in a cutoff.
  However, B does not want to interfere with the cutoff A already made. B creates a new cutoff with the same date as the one of A, and when he generates lines,
  only retrieves the one that were not already in the cutoff of A.

- One user wants to create several cutoff at the same date, but for different journals/accounts

