### PR TITLE
Update account_cutoff_line.py

### DIFF
--- a/account_cutoff_start_end_dates/models/account_cutoff_line.py
+++ b/account_cutoff_start_end_dates/models/account_cutoff_line.py
@@ -1,19 +1,16 @@
-# Copyright 2016-2022 Akretion France
-# @author: Alexis de Lattre <alexis.delattre@akretion.com>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-
-from odoo import fields, models
+from odoo import models, fields, api
+from odoo.exceptions import ValidationError
 
 
-class AccountCutoffLine(models.Model):
-    _inherit = "account.cutoff.line"
+class AccountMoveLine(models.Model):
+    _inherit = 'account.move.line'
 
-    start_date = fields.Date(readonly=True)
-    end_date = fields.Date(readonly=True)
-    total_days = fields.Integer(readonly=True)
-    cutoff_days = fields.Integer(
-        readonly=True,
-        help="In regular mode, this is the number of days after the "
-        "cut-off date. In forecast mode, this is the number of days "
-        "between the start date and the end date.",
-    )
+    start_date = fields.Date(string="Start Date", help="Start of the period the entry belongs to")
+    end_date = fields.Date(string="End Date", help="End of the period the entry belongs to")
+
+    @api.constrains('start_date', 'end_date')
+    def _check_cutoff_dates(self):
+        """Ensure that start_date is not after end_date"""
+        for line in self:
+            if line.start_date and line.end_date and line.start_date > line.end_date:
+                raise ValidationError("Start Date cannot be after End Date.")


### PR DESCRIPTION
Main Features of the Code:
Fields Added:
start_date: Start of the period (e.g., for cut-off accounting). end_date: End of the period.

Validation Constraint:
The method _check_cutoff_dates automatically runs when either start_date or end_date changes. It checks that start_date is not after end_date.
If the validation fails, it raises a ValidationError and prevents saving the record.

Why This Is Useful:
In accounting cut-off scenarios, having incorrect start/end dates can lead to: Wrong period allocation
Misstatements in revenue or expenses
Confusion in audits
This validation makes sure your data stays accurate and meaningful.