### PR TITLE
[IMP] account_fiscal_year_closing: Avoid memory error

### DIFF
--- a/account_fiscal_year_closing/models/account_fiscalyear_closing.py
+++ b/account_fiscal_year_closing/models/account_fiscalyear_closing.py
@@ -590,9 +590,9 @@ class AccountFiscalyearClosingMapping(models.Model):
         if self.fyc_config_id.move_type == "opening":
             date = self.fyc_config_id.fyc_id.date_opening
         if account_lines:
-            balance = sum(account_lines.mapped("debit")) - sum(
-                account_lines.mapped("credit")
-            )
+            balance = account_lines.read_group(
+                [("id", "in", account_lines.ids)], ["balance:sum"], []
+            )[0]["balance"]
             if not float_is_zero(balance, precision_digits=precision):
                 move_line = {
                     "account_id": account.id,


### PR DESCRIPTION
`mapped` loads a lot of data in the cache, so when we are closing a fiscal year with a lot of lines the following exception might be raised:
```
  File "/opt/odoo/custom/oca/account-closing/account_fiscal_year_closing/models/account_fiscalyear_closing.py", line 291, in button_calculate
    res = self.calculate()
  File "/opt/odoo/custom/oca/account-closing/account_fiscal_year_closing/models/account_fiscalyear_closing.py", line 275, in calculate
    move, data = config.moves_create()
  File "/opt/odoo/custom/oca/account-closing/account_fiscal_year_closing/models/account_fiscalyear_closing.py", line 509, in moves_create
    move_lines = self._mapping_move_lines_get()
  File "/opt/odoo/custom/oca/account-closing/account_fiscal_year_closing/models/account_fiscalyear_closing.py", line 456, in _mapping_move_lines_get
    balance, move_line = account_map.move_line_prepare(account, lines)
  File "/opt/odoo/custom/oca/account-closing/account_fiscal_year_closing/models/account_fiscalyear_closing.py", line 593, in move_line_prepare
    balance = sum(account_lines.mapped("debit")) - sum(
  File "/usr/lib/python3/dist-packages/odoo/models.py", line 5292, in mapped
    recs = recs._fields[name].mapped(recs)
  File "/usr/lib/python3/dist-packages/odoo/fields.py", line 1109, in mapped
    self.__get__(first(remaining), type(remaining))
  File "/usr/lib/python3/dist-packages/odoo/fields.py", line 1019, in __get__
    recs._fetch_field(self)
  File "/usr/lib/python3/dist-packages/odoo/models.py", line 3078, in _fetch_field
    self._read(fnames)
  File "/usr/lib/python3/dist-packages/odoo/models.py", line 3175, in _read
    self.env.cache.update(fetched, field, values)
  File "/usr/lib/python3/dist-packages/odoo/api.py", line 817, in update
    field_cache.update(zip(records._ids, values))
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 652, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 317, in _handle_exception
    raise exception.with_traceback(None) from new_cause
MemoryError
```
