### PR TITLE
[18.0][IMP] account_invoice_start_end_dates: enforce start_date+end_date only on posted invoices

### DIFF
--- a/account_invoice_start_end_dates/models/account_move_line.py
+++ b/account_invoice_start_end_dates/models/account_move_line.py
@@ -14,7 +14,9 @@ class AccountMoveLine(models.Model):
     end_date = fields.Date(index=True)
     must_have_dates = fields.Boolean(related="product_id.must_have_dates")
 
-    @api.constrains("start_date", "end_date", "display_type", "product_id")
+    @api.constrains(
+        "start_date", "end_date", "display_type", "product_id", "parent_state"
+    )
     def _check_start_end_dates(self):
         for moveline in self:
             if moveline.start_date and not moveline.end_date:
@@ -41,8 +43,13 @@ class AccountMoveLine(models.Model):
                         "name": moveline.display_name,
                     }
                 )
+            # We enforce start_end+end_date when product_id.must_have_dates=True
+            # only when posting the invoice, because some users want to use the
+            # module account_invoice_start_end_dates WITHOUT the module
+            # sale_start_end_dates for a good reason.
             if (
-                moveline.display_type == "product"
+                moveline.parent_state == "posted"
+                and moveline.display_type == "product"
                 and moveline.product_id.must_have_dates
                 and not moveline.start_date
             ):

--- a/account_invoice_start_end_dates/tests/test_invoice_start_end_dates.py
+++ b/account_invoice_start_end_dates/tests/test_invoice_start_end_dates.py
@@ -27,7 +27,6 @@ class TestInvoiceStartEndDates(TransactionCase):
             {
                 "name": "Maintenance contract",
                 "type": "service",
-                "categ_id": cls.env.ref("product.product_category_5").id,
                 "must_have_dates": True,
             }
         )
@@ -89,26 +88,27 @@ class TestInvoiceStartEndDates(TransactionCase):
         )
 
     def test_missing_date(self):
+        inv = self.move_model.create(
+            {
+                "partner_id": self.partner.id,
+                "move_type": "out_invoice",
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.maint_product.id,
+                            "name": "Maintenance IPBX 12 mois",
+                            "price_unit": 1200,
+                            "quantity": 1,
+                            "account_id": self.account_revenue.id,
+                            "start_date": False,
+                            "end_date": False,
+                        }
+                    )
+                ],
+            }
+        )
         with self.assertRaises(ValidationError):
-            self.move_model.create(
-                {
-                    "partner_id": self.partner.id,
-                    "move_type": "out_invoice",
-                    "invoice_line_ids": [
-                        Command.create(
-                            {
-                                "product_id": self.maint_product.id,
-                                "name": "Maintenance IPBX 12 mois",
-                                "price_unit": 1200,
-                                "quantity": 1,
-                                "account_id": self.account_revenue.id,
-                                "start_date": False,
-                                "end_date": False,
-                            }
-                        )
-                    ],
-                }
-            )
+            inv.action_post()
 
     def test_date_order(self):
         with self.assertRaises(ValidationError):


### PR DESCRIPTION
We enforce start_end+end_date when product_id.must_have_dates=True only when posting the invoice, because some users want to use the module account_invoice_start_end_dates WITHOUT the module sale_start_end_dates for a good reason.

This is a sort of revert of the change I made in dec 2024 in this commit: https://github.com/OCA/account-closing/commit/c988c2647f203864cdf10f0bf600dd25c020dc30