### PR TITLE
ADD to account_cutoff_start_end_dates the possiblity to include tax lines with start and end dates

### DIFF
--- a/account_cutoff_start_end_dates/models/account_cutoff.py
+++ b/account_cutoff_start_end_dates/models/account_cutoff.py
@@ -24,6 +24,11 @@ class AccountCutoff(models.Model):
     state = fields.Selection(selection_add=[("forecast", "Forecast")])
     start_date = fields.Date(help="This field is only for the forecast mode")
     end_date = fields.Date(help="This field is only for the forecast mode")
+    include_tax_lines = fields.Boolean(
+        help="If enabled, tax move lines (display_type = 'tax') will also "
+        "be included in the cutoff computation alongside product lines. "
+        "Tax lines must have start and end dates set to be included.",
+    )
 
     @api.depends("company_id", "cutoff_type")
     def _compute_source_journal_ids(self):
@@ -176,9 +181,13 @@ class AccountCutoff(models.Model):
         if not self.source_journal_ids:
             raise UserError(_("You should set at least one Source Journal."))
         mapping = self._get_mapping_dict()
+        if self.include_tax_lines:
+            display_types = ("product", "tax")
+        else:
+            display_types = ("product",)
         domain = [
             ("journal_id", "in", self.source_journal_ids.ids),
-            ("display_type", "=", "product"),
+            ("display_type", "in", display_types),
             ("company_id", "=", self.company_id.id),
             ("balance", "!=", 0),
         ]

--- a/account_cutoff_start_end_dates/tests/test_account_cutoff_prepaid.py
+++ b/account_cutoff_start_end_dates/tests/test_account_cutoff_prepaid.py
@@ -125,3 +125,107 @@ class TestCutoffPrepaid(AccountTestInvoicingCommon):
         # two invoices, but two lines (because the two cutoff lines
         # have been grouped into one line plus one counterpart)
         self.assertEqual(len(cutoff.move_id.line_ids), 2)
+
+    def test_include_tax_lines(self):
+        """Test that include_tax_lines includes tax move lines in cutoff."""
+        tax = self.env["account.tax"].create(
+            {
+                "name": "Test Tax 10%",
+                "type_tax_use": "purchase",
+                "amount_type": "percent",
+                "amount": 10,
+                "company_id": self.company.id,
+            }
+        )
+        amount = self._days("04-01", "06-30")
+        amount_2months = self._days("05-01", "06-30")
+        # Create invoice with tax
+        invoice = self.inv_model.create(
+            {
+                "company_id": self.company.id,
+                "invoice_date": self._date("01-15"),
+                "date": self._date("01-15"),
+                "partner_id": self.partner.id,
+                "journal_id": self.purchase_journal.id,
+                "move_type": "in_invoice",
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "name": "expense with tax",
+                            "price_unit": amount,
+                            "quantity": 1,
+                            "account_id": self.account_expense.id,
+                            "start_date": self._date("04-01"),
+                            "end_date": self._date("06-30"),
+                            "tax_ids": [Command.set(tax.ids)],
+                        },
+                    )
+                ],
+            }
+        )
+        invoice.action_post()
+        # Set start_date and end_date on tax lines (not auto-propagated)
+        tax_lines = invoice.line_ids.filtered(lambda line: line.display_type == "tax")
+        self.assertTrue(tax_lines, "Invoice should have tax lines")
+        tax_lines.write(
+            {
+                "start_date": self._date("04-01"),
+                "end_date": self._date("06-30"),
+            }
+        )
+        tax_line_balance = sum(tax_lines.mapped("balance"))
+
+        # Without include_tax_lines: only product line in cutoff
+        cutoff = self._create_cutoff("01-31")
+        cutoff.get_lines()
+        self.assertEqual(len(cutoff.line_ids), 1)
+        self.assertEqual(cutoff.total_cutoff_amount, amount)
+        cutoff.unlink()
+
+        # With include_tax_lines, cutoff before period: full amount + tax
+        cutoff = self.cutoff_model.create(
+            {
+                "company_id": self.company.id,
+                "cutoff_date": self._date("01-31"),
+                "cutoff_type": "prepaid_expense",
+                "include_tax_lines": True,
+            }
+        )
+        cutoff.get_lines()
+        self.assertEqual(len(cutoff.line_ids), 2)
+        self.assertEqual(
+            cutoff.total_cutoff_amount,
+            amount + tax_line_balance,
+        )
+
+        # With include_tax_lines, cutoff in the middle: prorated amount + tax
+        cutoff = self.cutoff_model.create(
+            {
+                "company_id": self.company.id,
+                "cutoff_date": self._date("04-30"),
+                "cutoff_type": "prepaid_expense",
+                "include_tax_lines": True,
+            }
+        )
+        cutoff.get_lines()
+        self.assertEqual(len(cutoff.line_ids), 2)
+        expected_tax_cutoff = self.company.currency_id.round(
+            tax_line_balance * amount_2months / amount
+        )
+        self.assertEqual(
+            cutoff.total_cutoff_amount,
+            amount_2months + expected_tax_cutoff,
+        )
+
+        # With include_tax_lines, cutoff at end of period: no cutoff
+        cutoff = self.cutoff_model.create(
+            {
+                "company_id": self.company.id,
+                "cutoff_date": self._date("06-30"),
+                "cutoff_type": "prepaid_expense",
+                "include_tax_lines": True,
+            }
+        )
+        cutoff.get_lines()
+        self.assertEqual(len(cutoff.line_ids), 0)
+        self.assertEqual(cutoff.total_cutoff_amount, 0)

--- a/account_cutoff_start_end_dates/views/account_cutoff.xml
+++ b/account_cutoff_start_end_dates/views/account_cutoff.xml
@@ -73,6 +73,7 @@
                     widget="many2many_tags"
                     readonly="state == 'done'"
                 />
+                <field name="include_tax_lines" readonly="state == 'done'" />
             </field>
             <button name="get_lines" position="attributes">
                 <attribute


### PR DESCRIPTION

New field include_tax_lines: If enabled, tax move lines (display_type = 'tax') will also be included in the cutoff computation alongside product lines. Tax lines must have start and end dates set to be included

Rif https://github.com/OCA/account-closing/issues/361