### PR TITLE
[18.0][FIX] account_invoice_start_end_dates: Avoid same-label warning

### DIFF
--- a/account_invoice_start_end_dates/models/account_move_line.py
+++ b/account_invoice_start_end_dates/models/account_move_line.py
@@ -10,8 +10,8 @@ from odoo.tools.misc import format_date
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
 
-    start_date = fields.Date(index=True)
-    end_date = fields.Date(index=True)
+    start_date = fields.Date("Line Start Date", index=True)
+    end_date = fields.Date("Line End Date", index=True)
     must_have_dates = fields.Boolean(related="product_id.must_have_dates")
 
     @api.constrains(

--- a/account_invoice_start_end_dates/views/account_move_line.xml
+++ b/account_invoice_start_end_dates/views/account_move_line.xml
@@ -12,8 +12,12 @@
         <field name="arch" type="xml">
             <field name="date_maturity" position="after">
                 <field name="must_have_dates" invisible="1" />
-                <field name="start_date" required="must_have_dates" />
-                <field name="end_date" required="must_have_dates" />
+                <field
+                    name="start_date"
+                    required="must_have_dates"
+                    string="Start Date"
+                />
+                <field name="end_date" required="must_have_dates" string="End Date" />
             </field>
         </field>
     </record>
@@ -24,8 +28,8 @@
         <field name="arch" type="xml">
             <field name="date_maturity" position="after">
                 <field name="must_have_dates" column_invisible="1" />
-                <field name="start_date" optional="hide" />
-                <field name="end_date" optional="hide" />
+                <field name="start_date" optional="hide" string="Start Date" />
+                <field name="end_date" optional="hide" string="End Date" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
Odoo's account_accountant has two fields with the same label on the same model. Avoid warning by renaming the fields in Python while keeping the same label in the views. 

Fields: `account_accountant/models/account_move.py:446`

Warnings:
```
WARNING odoo.addons.base.models.ir_model: Two fields (start_date, deferred_start_date) of account.move.line() have the same label: Start Date. [Modules: account_invoice_start_end_dates and account_accountant] 
WARNING odoo.addons.base.models.ir_model: Two fields (end_date, deferred_end_date) of account.move.line() have the same label: End Date. [Modules: account_invoice_start_end_dates and account_accountant] 
```