### PR TITLE
[FIX] account_invoice_start_end_dates: avoid check on deferred lines

### DIFF
--- a/account_invoice_start_end_dates/models/account_move_line.py
+++ b/account_invoice_start_end_dates/models/account_move_line.py
@@ -51,6 +51,7 @@ class AccountMoveLine(models.Model):
                 moveline.parent_state == "posted"
                 and moveline.display_type == "product"
                 and moveline.product_id.must_have_dates
+                and moveline.journal_id.type in ("sale", "purchase")
                 and not moveline.start_date
             ):
                 raise ValidationError(


### PR DESCRIPTION
The constrains raises for [generated deferred entries](https://github.com/odoo/enterprise/blob/4565d62391f939b5a1fb6702041e3d9e58b9f496/account_accountant/models/account_move.py#L114) even though the posted entry has valid dates.