### PR TITLE
account_cutoff_accrual_picking: fix wrong currency conversion on tax

### DIFF
--- a/account_cutoff_accrual_picking/models/account_cutoff.py
+++ b/account_cutoff_accrual_picking/models/account_cutoff.py
@@ -136,7 +136,7 @@ class AccountCutoff(models.Model):
                 handle_price_include=False,
             )
             vals["tax_line_ids"] = self._prepare_tax_lines(
-                tax_compute_all_res, self.company_currency_id
+                tax_compute_all_res, currency
             )
         return vals
 


### PR DESCRIPTION
@alexis-via fix currency conversion on tax line, the currency passed to the prepare method should be the currency of the record