### PR TITLE
[18.0][IMP] account_cutoff_base: port auto_reverse feature from v16

### DIFF
--- a/account_cutoff_base/__manifest__.py
+++ b/account_cutoff_base/__manifest__.py
@@ -8,7 +8,7 @@
     "category": "Accounting & Finance",
     "summary": "Base module for Account Cut-offs",
     "author": "Akretion,Odoo Community Association (OCA)",
-    "maintainers": ["alexis-via"],
+    "maintainers": ["alexis-via", "jbaudoux"],
     "website": "https://github.com/OCA/account-closing",
     "depends": ["account"],
     "data": [

--- a/account_cutoff_base/i18n/fr.po
+++ b/account_cutoff_base/i18n/fr.po
@@ -158,6 +158,20 @@ msgid "Attachment Count"
 msgstr "Nombre de pièces jointes"
 
 #. module: account_cutoff_base
+#: model:ir.model.fields,field_description:account_cutoff_base.field_account_cutoff__auto_reverse
+msgid "Auto Reverse"
+msgstr "Extourne automatique"
+
+#. module: account_cutoff_base
+#: model:ir.model.fields,help:account_cutoff_base.field_account_cutoff__auto_reverse
+msgid ""
+"Automatically reverse created move on following day. Use this if you accrue "
+"a value end of period that you want to reverse begin of next period"
+msgstr ""
+"Extourner automatiquement le mouvement sur le jour suivant. Utilisez ceci si vous provisionnez "
+"un montant à la fin d'une période et que vous voulez l'extourner au début de la période suivante"
+
+#. module: account_cutoff_base
 #: model_terms:ir.ui.view,arch_db:account_cutoff_base.account_cutoff_form
 msgid "Back to Draft"
 msgstr "Remettre en brouillon"
@@ -280,6 +294,11 @@ msgstr "Date de la provision"
 #: model:ir.model.fields,field_description:account_cutoff_base.field_account_cutoff__move_id
 msgid "Cut-off Journal Entry"
 msgstr "Pièce comptable de la provision"
+
+#. module: account_cutoff_base
+#: model:ir.model.fields,field_description:account_cutoff_base.field_account_cutoff__move_reversal_id
+msgid "Cut-off Journal Entry Reversal"
+msgstr "Pièce comptable de l'extourne"
 
 #. module: account_cutoff_base
 #: model:ir.model.fields,field_description:account_cutoff_base.field_account_cutoff__line_ids
@@ -797,6 +816,13 @@ msgid "You cannot delete cutoff records that are in done state."
 msgstr ""
 "Il n'est pas possible de supprimer les provisions qui sont à l'état "
 "'Terminé'."
+
+#. module: account_cutoff_base
+#. odoo-python
+#: code:addons/account_cutoff_base/models/account_cutoff.py:0
+#, python-format
+msgid "reversal of: "
+msgstr "extourne de: "
 
 #~ msgid "Analytic Distribution Search"
 #~ msgstr "Recherche de distribution analytique"

--- a/account_cutoff_base/models/account_cutoff.py
+++ b/account_cutoff_base/models/account_cutoff.py
@@ -1,4 +1,5 @@
-# Copyright 2013-2021 Akretion (http://www.akretion.com/)
+# Copyright 2013 Akretion (http://www.akretion.com/)
+# Copyright 2018 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # @author: Alexis de Lattre <alexis.delattre@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
@@ -49,6 +50,24 @@ class AccountCutoff(models.Model):
         copy=False,
         check_company=True,
     )
+    auto_reverse = fields.Boolean(
+        help="Automatically reverse created move on following day. Use this "
+        "if you accrue a value end of period that you want to reverse "
+        "begin of next period",
+    )
+    move_reversal_id = fields.Many2one(
+        "account.move",
+        string="Cut-off Journal Entry Reversal",
+        compute="_compute_move_reversal_id",
+    )
+
+    @api.depends("move_id.reversal_move_ids", "move_id.reversal_move_ids.state")
+    def _compute_move_reversal_id(self):
+        for rec in self:
+            rec.move_reversal_id = rec.move_id.reversal_move_ids.filtered(
+                lambda m: m.state != "cancel"
+            )[:1]
+
     move_ref = fields.Char(
         string="Reference of the Cut-off Journal Entry",
         compute="_compute_move_ref",
@@ -207,6 +226,10 @@ class AccountCutoff(models.Model):
 
     def back2draft(self):
         self.ensure_one()
+        if self.move_reversal_id:
+            self.move_reversal_id.line_ids.remove_move_reconcile()
+            self.move_reversal_id.unlink()
+            self.move_id.line_ids.remove_move_reconcile()
         if self.move_id:
             self.move_id.unlink()
         self.write({"state": "draft"})
@@ -339,6 +362,20 @@ class AccountCutoff(models.Model):
         move = move_obj.create(vals)
         if self.company_id.post_cutoff_move:
             move._post(soft=False)
+
+        if self.auto_reverse:
+            next_day = fields.Date.from_string(self.cutoff_date) + relativedelta(days=1)
+            rev_move = move._reverse_moves(
+                [
+                    {
+                        "date": next_day,
+                        "ref": _("reversal of: ") + move.ref,
+                    }
+                ]
+            )
+            if self.company_id.post_cutoff_move:
+                rev_move._post(soft=False)
+
         self.write({"move_id": move.id, "state": "done"})
         self.message_post(body=_("Journal entry generated"))
 

--- a/account_cutoff_base/tests/test_account_cutoff.py
+++ b/account_cutoff_base/tests/test_account_cutoff.py
@@ -1,37 +1,133 @@
+# Copyright 2018 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo.tests.common import TransactionCase
+from dateutil.relativedelta import relativedelta
+
+from odoo import Command, fields
+from odoo.tests import tagged
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
 
-class TestAccountCutoff(TransactionCase):
-    def test_compute_cutoff_account_id(self):
-        company = self.env.company
-        random_account = self.env["account.account"].search(
-            [("company_ids", "in", company.id)], limit=1
+@tagged("post_install", "-at_install")
+class TestAccountCutoff(AccountTestInvoicingCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.company = cls.env.company
+        cls.cutoff_journal = cls.env["account.journal"].create(
+            {
+                "code": "cop0",
+                "company_id": cls.company.id,
+                "name": "Cutoff Journal Base",
+                "type": "general",
+            }
         )
-        if random_account:
-            company.default_accrued_expense_account_id = random_account.id
-            company.default_accrued_revenue_account_id = random_account.id
+        cls.cutoff_account = cls.env["account.account"].create(
+            {
+                "name": "Cutoff Base Account",
+                "code": "ACB480000",
+                "company_ids": [Command.set([cls.company.id])],
+                "account_type": "liability_current",
+            }
+        )
+        cls.line_account = cls.env["account.account"].create(
+            {
+                "name": "Base Account",
+                "code": "ACB220000",
+                "company_ids": [Command.set([cls.company.id])],
+                "account_type": "liability_current",
+            }
+        )
+        cls.company.write(
+            {
+                "default_cutoff_journal_id": cls.cutoff_journal.id,
+                "default_accrued_expense_account_id": cls.cutoff_account.id,
+                "default_accrued_revenue_account_id": cls.cutoff_account.id,
+            }
+        )
 
-            cutoff = self.env["account.cutoff"].create(
+    def _create_cutoff(self, cutoff_type="accrued_revenue", cutoff_date=None):
+        if cutoff_date is None:
+            cutoff_date = fields.Date.today()
+        cutoff = self.env["account.cutoff"].create(
+            {
+                "cutoff_type": cutoff_type,
+                "company_id": self.company.id,
+                "cutoff_date": cutoff_date,
+                "cutoff_account_id": self.cutoff_account.id,
+                "cutoff_journal_id": self.cutoff_journal.id,
+            }
+        )
+        cutoff.line_ids = [
+            Command.create(
                 {
-                    "company_id": company.id,
-                    "cutoff_type": "accrued_expense",
+                    "parent_id": cutoff.id,
+                    "account_id": self.line_account.id,
+                    "cutoff_account_id": self.cutoff_account.id,
+                    "cutoff_amount": 50,
                 }
             )
-            self.assertEqual(
-                cutoff.cutoff_account_id.id,
-                random_account.id,
-                f"The account must be equals to {random_account.id}",
-            )
-            cutoff2 = self.env["account.cutoff"].create(
-                {
-                    "company_id": company.id,
-                    "cutoff_type": "accrued_revenue",
-                }
-            )
-            self.assertEqual(
-                cutoff2.cutoff_account_id.id,
-                random_account.id,
-                f"The account must be equals to {random_account.id}",
-            )
+        ]
+        return cutoff
+
+    def test_compute_cutoff_account_id(self):
+        cutoff = self.env["account.cutoff"].create(
+            {
+                "company_id": self.company.id,
+                "cutoff_type": "accrued_expense",
+            }
+        )
+        self.assertEqual(cutoff.cutoff_account_id, self.cutoff_account)
+        cutoff2 = self.env["account.cutoff"].create(
+            {
+                "company_id": self.company.id,
+                "cutoff_type": "accrued_revenue",
+            }
+        )
+        self.assertEqual(cutoff2.cutoff_account_id, self.cutoff_account)
+
+    def test_create_move_no_auto_reverse(self):
+        """create_move without auto_reverse creates no reversal entry"""
+        self.company.post_cutoff_move = False
+        cutoff = self._create_cutoff()
+        cutoff.auto_reverse = False
+        cutoff.create_move()
+        self.assertTrue(cutoff.move_id)
+        self.assertEqual(cutoff.move_id.state, "draft")
+        self.assertFalse(cutoff.move_reversal_id)
+
+    def test_create_move_auto_reverse(self):
+        """create_move with auto_reverse creates a reversal dated the next day"""
+        self.company.post_cutoff_move = False
+        cutoff_date = fields.Date.today()
+        cutoff = self._create_cutoff(cutoff_date=cutoff_date)
+        cutoff.auto_reverse = True
+        cutoff.create_move()
+        self.assertTrue(cutoff.move_id)
+        self.assertEqual(cutoff.move_id.state, "draft")
+        self.assertTrue(cutoff.move_reversal_id)
+        self.assertEqual(cutoff.move_reversal_id.state, "draft")
+        expected_reversal_date = cutoff_date + relativedelta(days=1)
+        self.assertEqual(cutoff.move_reversal_id.date, expected_reversal_date)
+
+    def test_create_move_auto_reverse_posted(self):
+        """With post_cutoff_move=True, both move and reversal are posted"""
+        self.company.post_cutoff_move = True
+        cutoff = self._create_cutoff()
+        cutoff.auto_reverse = True
+        cutoff.create_move()
+        self.assertEqual(cutoff.move_id.state, "posted")
+        self.assertEqual(cutoff.move_reversal_id.state, "posted")
+
+    def test_back2draft_clears_reversal(self):
+        """back2draft unlinks the move and clears the computed reversal field"""
+        self.company.post_cutoff_move = False
+        cutoff = self._create_cutoff()
+        cutoff.auto_reverse = True
+        cutoff.create_move()
+        self.assertTrue(cutoff.move_reversal_id)
+        cutoff.back2draft()
+        self.assertFalse(cutoff.move_id)
+        self.assertFalse(cutoff.move_reversal_id)

--- a/account_cutoff_base/views/account_cutoff.xml
+++ b/account_cutoff_base/views/account_cutoff.xml
@@ -68,6 +68,7 @@
                                 readonly="state == 'done'"
                             />
                             <field name="total_cutoff_amount" />
+                            <field name="auto_reverse" readonly="state == 'done'" />
                             <field
                                 name="source_move_state"
                                 widget="radio"
@@ -96,6 +97,7 @@
                             <field name="move_ref" readonly="state == 'done'" />
                             <field name="move_partner" readonly="state == 'done'" />
                             <field name="move_id" />
+                            <field name="move_reversal_id" />
                         </group>
                     </group>
                     <group name="lines">


### PR DESCRIPTION

issue [#374](https://github.com/OCA/account-closing/issues/374)
Port of [OCA/account-closing#270.](https://github.com/OCA/account-closing/pull/270) (merged in v16 on Oct 10, 2024).

The auto_reverse field was introduced in v16 but was never ported to v17 or v18 during migration.