### PR TITLE
[16.0][FIX] account_fiscal_year_closing: exclude cancelled moves when closing by partner

### DIFF
--- a/account_fiscal_year_closing/models/account_fiscalyear_closing.py
+++ b/account_fiscal_year_closing/models/account_fiscalyear_closing.py
@@ -668,6 +668,7 @@ class AccountFiscalyearClosingMapping(models.Model):
             [
                 ("company_id", "=", company_id),
                 ("account_id", "=", account.id),
+                ("move_id.state", "!=", "cancel"),
                 ("date", ">=", start),
                 ("date", "<=", end),
             ],

--- a/account_fiscal_year_closing/tests/test_account_fiscal_year_closing.py
+++ b/account_fiscal_year_closing/tests/test_account_fiscal_year_closing.py
@@ -215,6 +215,21 @@ class TestAccountFiscalYearClosing(AccountTestInvoicingCommon):
             "Customer invoice state is not out_invoice",
         )
 
+        # A cancelled invoice must not be taken into account by the closing.
+        # Its journal items stay in the database, so closing the receivable and
+        # payable accounts by partner used to pick them up and the closing move
+        # came out unbalanced.
+        cancelled_invoice = self.create_simple_invoice(
+            self.the_day, self.env.ref("base.res_partner_4"), "out_invoice"
+        )
+        cancelled_invoice.action_post()
+        cancelled_invoice.button_draft()
+        cancelled_invoice.button_cancel()
+        self.assertTrue(
+            (cancelled_invoice.state == "cancel"),
+            "Cancelled invoice state is not Cancelled",
+        )
+
         move_lines = self.move_line_obj.search([])
         account_types = move_lines.mapped("account_id.account_type")
         self.assertTrue(
@@ -248,11 +263,17 @@ class TestAccountFiscalYearClosing(AccountTestInvoicingCommon):
         )
         # Income
         inc_move_lines = self.move_line_obj.search(
-            [("account_id.account_type", "=", "income")]
+            [
+                ("account_id.account_type", "=", "income"),
+                ("move_id.state", "!=", "cancel"),
+            ]
         )
         # Expenses
         exp_move_lines = self.move_line_obj.search(
-            [("account_id.account_type", "=", "expense")]
+            [
+                ("account_id.account_type", "=", "expense"),
+                ("move_id.state", "!=", "cancel"),
+            ]
         )
         # Current Assets
         cas_move_lines = self.move_line_obj.search(


### PR DESCRIPTION
## Problem

Running the fiscal year closing on a database that contains cancelled moves produces an
unbalanced closing entry, and the module refuses to create it: the *"Unbalanced journal
entry found"* wizard comes up instead.

## Root cause

`AccountFiscalyearClosingMapping` reads the journal items of the year through two
different methods, and only one of them filters out cancelled moves:

| Method | Used when the closing type is | Filters `move_id.state != 'cancel'` |
|---|---|---|
| `account_lines_get` | `balance` | yes |
| `account_partners_get` | `unreconciled` | **no** |

In Odoo a cancelled move keeps its `account.move.line` records — reports ignore them by
filtering on the state. So accounts closed by balance are computed *without* cancelled
moves while accounts closed by partner are computed *with* them.

The closing move posts, for every account, the opposite of its balance, so it only
balances if the sum of all the included balances is zero. Mixing two filtering criteria
breaks that, by exactly the net amount of the cancelled moves in the accounts closed by
partner.

This is not an edge case for companies using a single receivable account for all
customers and a single payable account for all suppliers, which is the usual setup in
Spain: those accounts *have* to be closed by partner to keep the detail per third party,
so the only affected branch is the one they need. On the database where this was found the
closing came out 86,613.45 € off, entirely explained by 16 journal items belonging to 15
cancelled invoices.

## Fix

Add to `account_partners_get` the same domain leaf `account_lines_get` already uses, so
both closing types read the same journal items.

## Test

`test_account_closing` already builds a closing configuration with
`closing_type_default = "unreconciled"` mapping the receivable and payable accounts, and
already ends by asserting that no unbalanced move is produced. Reproducing the bug only
needed a cancelled invoice, so that is all the test adds.

The expected profit and loss amounts are now computed from non-cancelled journal items as
well: they are compared against what the module writes, and the module regularises income
and expense accounts through `account_lines_get`, which excludes cancelled moves.

Verified on a clean database with demo data:

- without the fix → `AssertionError: True is not false : There are unbalanced move/s in the closing moves!`
- with the fix → `0 failed, 0 error(s) of 2 tests`

## Other branches

The same asymmetry is present in `14.0` and `18.0`, so the fix applies there too and I am
happy to forward-port it if this is accepted. In `12.0` neither method filters the state,
so that branch is at least self-consistent.
