### PR TITLE
[16.0] account_cutoff_accrual_order: multi-company & return

### DIFF
--- a/account_cutoff_accrual_order_base/models/order_line_mixin.py
+++ b/account_cutoff_accrual_order_base/models/order_line_mixin.py
@@ -148,8 +148,10 @@ class OrderLineCutoffAccrualMixin(models.AbstractModel):
 
     @api.model
     def _get_cutoff_accrual_lines_domain(self, cutoff):
-        domain = []
-        domain.append(("is_cutoff_accrual_excluded", "!=", True))
+        domain = [
+            ("is_cutoff_accrual_excluded", "!=", True),
+            ("company_id", "=", cutoff.company_id.id),
+        ]
         return domain
 
     @api.model

--- a/account_cutoff_accrual_purchase/models/purchase_order_line.py
+++ b/account_cutoff_accrual_purchase/models/purchase_order_line.py
@@ -57,6 +57,7 @@ class PurchaseOrderLine(models.Model):
         # Take all invoices impacting the cutoff
         # FIXME: what about ("move_id.payment_state", "=", "invoicing_legacy")
         domain = [
+            ("company_id", "=", cutoff.company_id.id),
             ("purchase_line_id.is_cutoff_accrual_excluded", "!=", True),
             ("move_id.move_type", "in", ("in_invoice", "in_refund")),
             ("purchase_line_id", "!=", False),
@@ -82,8 +83,9 @@ class PurchaseOrderLine(models.Model):
                 FROM account_move_line
                 WHERE id in %s
             )
+            AND company_id = %s
             """,
-            (tuple(invoice_line_after.ids),),
+            (tuple(invoice_line_after.ids), cutoff.company_id.id),
         )
         purchase_ids = [x[0] for x in self.env.cr.fetchall()]
         lines = self.env["purchase.order.line"].search(

--- a/account_cutoff_accrual_purchase/tests/common.py
+++ b/account_cutoff_accrual_purchase/tests/common.py
@@ -1,0 +1,86 @@
+# Copyright 2018 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from datetime import datetime
+
+from dateutil.relativedelta import relativedelta
+
+from odoo import Command, fields
+from odoo.tests.common import Form
+
+from odoo.addons.account_cutoff_accrual_order_base.tests.common import (
+    TestAccountCutoffAccrualOrderCommon,
+)
+
+
+class TestAccountCutoffAccrualPurchaseCommon(TestAccountCutoffAccrualOrderCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Removing all existing PO
+        cls.env.cr.execute("DELETE FROM purchase_order;")
+        # Create PO
+        cls.tax_purchase = cls.env.company.account_purchase_tax_id
+        cls.cutoff_account = cls.env["account.account"].create(
+            {
+                "name": "account accrued expense",
+                "code": "accountAccruedExpense",
+                "account_type": "asset_current",
+                "company_id": cls.env.company.id,
+            }
+        )
+        cls.tax_purchase.account_accrued_expense_id = cls.cutoff_account
+        cls.po = cls.env["purchase.order"].create(
+            {
+                "partner_id": cls.partner.id,
+                "order_line": [
+                    Command.create(
+                        {
+                            "name": p.name,
+                            "product_id": p.id,
+                            "product_qty": 5,
+                            "product_uom": p.uom_po_id.id,
+                            "price_unit": 100,
+                            "date_planned": fields.Date.to_string(
+                                datetime.today() + relativedelta(days=-15)
+                            ),
+                            "analytic_distribution": {
+                                str(cls.analytic_account.id): 100.0
+                            },
+                            "taxes_id": [Command.set(cls.tax_purchase.ids)],
+                        },
+                    )
+                    for p in cls.products
+                ],
+            }
+        )
+        type_cutoff = "accrued_expense"
+        cls.expense_cutoff = (
+            cls.env["account.cutoff"]
+            .with_context(default_cutoff_type=type_cutoff)
+            .create(
+                {
+                    "cutoff_type": type_cutoff,
+                    "order_line_model": "purchase.order.line",
+                    "company_id": 1,
+                    "cutoff_date": fields.Date.today(),
+                }
+            )
+        )
+
+    @classmethod
+    def _confirm_po(cls):
+        cls.po.button_confirm()
+        cls.po.button_approve(force=True)
+
+    @classmethod
+    def _create_po_invoice(cls, date):
+        invoice_form = Form(
+            cls.env["account.move"].with_context(
+                default_move_type="in_invoice", default_purchase_id=cls.po.id
+            )
+        )
+        invoice_form.invoice_date = date
+        invoice = invoice_form.save()
+        invoice.date = date
+        return invoice

--- a/account_cutoff_accrual_purchase_stock/models/purchase_order_line.py
+++ b/account_cutoff_accrual_purchase_stock/models/purchase_order_line.py
@@ -28,8 +28,9 @@ class PurchaseOrderLine(models.Model):
                   AND date >= %s
                   AND purchase_line_id IS NOT NULL
             )
+            AND company_id = %s
         """,
-            (cutoff_nextday,),
+            (cutoff_nextday, cutoff.company_id.id),
         )
         purchase_ids = [x[0] for x in self.env.cr.fetchall()]
         lines = self.env["purchase.order.line"].search(

--- a/account_cutoff_accrual_sale/models/sale_order_line.py
+++ b/account_cutoff_accrual_sale/models/sale_order_line.py
@@ -105,6 +105,7 @@ class SaleOrderLine(models.Model):
         # Take all invoices impacting the cutoff
         # FIXME: what about ("move_id.payment_state", "=", "invoicing_legacy")
         domain = [
+            ("company_id", "=", cutoff.company_id.id),
             ("sale_line_ids.is_cutoff_accrual_excluded", "!=", True),
             ("move_id.move_type", "in", ("out_invoice", "out_refund")),
             ("sale_line_ids", "!=", False),
@@ -130,8 +131,9 @@ class SaleOrderLine(models.Model):
                 FROM sale_order_line_invoice_rel
                 WHERE invoice_line_id in %s
             )
+            AND company_id = %s
             """,
-            (tuple(invoice_line_after.ids),),
+            (tuple(invoice_line_after.ids), cutoff.company_id.id),
         )
         sale_ids = [x[0] for x in self.env.cr.fetchall()]
         lines = self.env["sale.order.line"].search(
@@ -166,7 +168,7 @@ class SaleOrderLine(models.Model):
         self.ensure_one()
         if self.product_id.invoice_policy == "order":
             date_local = self.order_id.date_order
-            company_tz = self.env.company.partner_id.tz or "UTC"
+            company_tz = self.company_id.partner_id.tz or "UTC"
             date_utc = fields.Datetime.context_timestamp(
                 self.with_context(tz=company_tz),
                 date_local,

--- a/account_cutoff_accrual_sale/models/sale_order_line.py
+++ b/account_cutoff_accrual_sale/models/sale_order_line.py
@@ -167,11 +167,10 @@ class SaleOrderLine(models.Model):
         """Return first delivery date"""
         self.ensure_one()
         if self.product_id.invoice_policy == "order":
-            date_local = self.order_id.date_order
-            company_tz = self.company_id.partner_id.tz or "UTC"
-            date_utc = fields.Datetime.context_timestamp(
-                self.with_context(tz=company_tz),
-                date_local,
-            )
-            return date_utc.date()
+            tz = self.order_id.company_id.partner_id.tz or "UTC"
+            date = fields.Datetime.context_timestamp(
+                self.with_context(tz=tz),
+                max(self.order_id.date_order, self.create_date),
+            ).date()
+            return date
         return

--- a/account_cutoff_accrual_sale/tests/common.py
+++ b/account_cutoff_accrual_sale/tests/common.py
@@ -26,7 +26,7 @@ class TestAccountCutoffAccrualSaleCommon(TestAccountCutoffAccrualOrderCommon):
         cls.env.cr.execute("DELETE FROM sale_order;")
         # Make service product invoicable on order
         cls.env.ref("product.expense_product").invoice_policy = "order"
-        # Create SO and confirm
+        # Create SO
         cls.price = 100
         cls.qty = 5
         cls.so = cls.env["sale.order"].create(

--- a/account_cutoff_accrual_sale_stock/models/sale_order_line.py
+++ b/account_cutoff_accrual_sale_stock/models/sale_order_line.py
@@ -28,8 +28,9 @@ class SaleOrderLine(models.Model):
                   AND date >= %s
                   AND sale_line_id IS NOT NULL
             )
+            AND company_id = %s
         """,
-            (cutoff_nextday,),
+            (cutoff_nextday, cutoff.company_id.id),
         )
         sale_ids = [x[0] for x in self.env.cr.fetchall()]
         lines = self.env["sale.order.line"].search(

--- a/account_cutoff_accrual_sale_stock/models/sale_order_line.py
+++ b/account_cutoff_accrual_sale_stock/models/sale_order_line.py
@@ -3,7 +3,8 @@
 
 import logging
 
-from odoo import models
+from odoo import fields, models
+from odoo.tools import float_compare
 
 _logger = logging.getLogger(__name__)
 
@@ -43,10 +44,43 @@ class SaleOrderLine(models.Model):
         self.ensure_one()
         if self.qty_delivered_method != "stock_move":
             return super()._get_cutoff_accrual_delivered_min_date()
-        stock_moves = self.move_ids.filtered(lambda m: m.state == "done")
-        if not stock_moves:
-            return
-        return min(stock_moves.mapped("date")).date()
+        tz = self.order_id.company_id.partner_id.tz or "UTC"
+        for move in self.move_ids.sorted("date"):
+            if move.state != "done":
+                continue
+            if move.picking_code != "outgoing" and self.product_uom_qty > 0:
+                continue
+            if move.picking_code != "incoming" and self.product_uom_qty < 0:
+                continue
+            if not move.product_qty:
+                continue
+            date = fields.Datetime.context_timestamp(
+                self.with_context(tz=tz),
+                move.date,
+            ).date()
+            if move.returned_move_ids:
+                returned_qty_same_month = sum(
+                    move.returned_move_ids.filtered(
+                        lambda m, fields=fields: m.state == "done"
+                        and fields.Datetime.context_timestamp(
+                            self.with_context(tz=tz),
+                            m.date,
+                        )
+                        .date()
+                        .month
+                        == date.month
+                    ).mapped("product_qty")
+                )
+                if (
+                    float_compare(
+                        move.product_qty,
+                        returned_qty_same_month,
+                        precision_rounding=move.product_id.uom_id.rounding,
+                    )
+                    <= 0
+                ):
+                    continue
+            return date
 
     def _get_cutoff_accrual_delivered_stock_quantity(self, cutoff):
         self.ensure_one()

--- a/account_cutoff_accrual_sale_stock_delivery/__init__.py
+++ b/account_cutoff_accrual_sale_stock_delivery/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/account_cutoff_accrual_sale_stock_delivery/models/__init__.py
+++ b/account_cutoff_accrual_sale_stock_delivery/models/__init__.py
@@ -1,4 +1,1 @@
-# Copyright 2018 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-
 from . import sale_order_line

--- a/account_cutoff_accrual_sale_stock_delivery/models/sale_order_line.py
+++ b/account_cutoff_accrual_sale_stock_delivery/models/sale_order_line.py
@@ -1,0 +1,38 @@
+# Copyright 2026 Jacques-Etienne Baudoux (BCIM sprl) <je@bcim.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class SaleOrderLine(models.Model):
+    _name = "sale.order.line"
+    _inherit = ["sale.order.line", "order.line.cutoff.accrual.mixin"]
+
+    def _get_cutoff_accrual_delivered_min_date(self):
+        self.ensure_one()
+        if not self.is_delivery:
+            return super()._get_cutoff_accrual_delivered_min_date()
+        # For a delivery line, the invoicing date is the first delivery date of
+        # any other invoiceable line
+        order_lines = self.order_id.order_line.filtered(
+            lambda line: not line.is_delivery
+            and not line.is_downpayment
+            and not line.display_type
+        )
+        dates = list(
+            filter(
+                None,
+                (line._get_cutoff_accrual_delivered_min_date() for line in order_lines),
+            )
+        )
+        if not dates:
+            return
+        date = min(dates)
+        # In case the delivery line has been created later, it could not have
+        # been invoiced before it's creation
+        tz = self.order_id.company_id.partner_id.tz or "UTC"
+        create_date = fields.Datetime.context_timestamp(
+            self.with_context(tz=tz),
+            self.create_date,
+        ).date()
+        return max(create_date, date)

--- a/account_cutoff_accrual_sale_stock_delivery/tests/test_cutoff_revenue_on_delivery_with_shipping.py
+++ b/account_cutoff_accrual_sale_stock_delivery/tests/test_cutoff_revenue_on_delivery_with_shipping.py
@@ -3,6 +3,10 @@
 
 from datetime import timedelta
 
+from freezegun import freeze_time
+
+from odoo import fields
+
 from odoo.addons.account_cutoff_accrual_sale_stock.tests.common import (
     TestAccountCutoffAccrualSaleStockCommon,
 )
@@ -19,6 +23,13 @@ class TestAccountCutoffAccrualSaleStockOnDeliveryWithShipping(
             lambda line: line.product_id.detailed_type == "service"
         )
         sol.is_delivery = True
+
+    def test_accrued_revenue_on_so_only_confirmed(self):
+        """Test cutoff based on SO only confirmed."""
+        cutoff = self.revenue_cutoff
+        self.so.action_confirm()
+        cutoff.get_lines()
+        self.assertEqual(len(cutoff.line_ids), 0, "No cutoff lines should be found")
 
     def test_accrued_revenue_on_so_not_invoiced(self):
         """Test cutoff based on SO where qty_delivered > qty_invoiced."""
@@ -258,6 +269,54 @@ class TestAccountCutoffAccrualSaleStockOnDeliveryWithShipping(
             self.assertEqual(
                 line.cutoff_amount, 100 * 2, "SO line cutoff amount incorrect"
             )
+
+    def test_accrued_revenue_on_so_all_after_cutoff(self):
+        """Test cutoff update when delivery and invoice after cutoff date.
+
+        Ensure no error is raised.
+        """
+        cutoff = self.revenue_cutoff
+        self.so.action_confirm()
+        cutoff.state = "done"
+        next_month = fields.Datetime.add(fields.Datetime.now(), months=1)
+        with freeze_time(next_month):
+            self._do_picking(2)
+            # Make invoice
+            invoice = self.so._create_invoices(final=True)
+            # Validate invoice
+            invoice.action_post()
+
+    def test_accrued_revenue_on_so_returned_and_resend_after_cutoff(self):
+        """Test cutoff update when delivery and invoice after cutoff date.
+
+        Case with a delivery and return before cutoff.
+        Ensure no error is raised.
+        """
+        cutoff = self.revenue_cutoff
+        qty_done = 2
+        self._confirm_so_and_do_picking(qty_done)
+        delivery = self.so.picking_ids.filtered(lambda p: p.state == "done")
+        self.assertEqual(len(delivery), 1, "1 done delivery should be found")
+        return_wizard = (
+            self.env["stock.return.picking"]
+            .with_context(active_model="stock.picking", active_id=delivery.id)
+            .new()
+        )
+        return_wizard._onchange_picking_id()  # Force filling the lines
+        delivery_return_id, _ = return_wizard._create_returns()
+        delivery_return = self.env["stock.picking"].browse(delivery_return_id)
+        delivery_return.move_line_ids.write({"qty_done": qty_done})
+        delivery_return._action_done()
+        cutoff.get_lines()
+        self.assertEqual(len(cutoff.line_ids), 0, "No cutoff lines should be found")
+        cutoff.state = "done"
+        next_month = fields.Datetime.add(fields.Datetime.now(), months=1)
+        with freeze_time(next_month):
+            self._do_picking(qty_done)
+            # Make invoice
+            invoice = self.so._create_invoices(final=True)
+            # Validate invoice
+            invoice.action_post()
 
     def test_accrued_revenue_on_so_force_invoiced_after(self):
         """Test cutoff when SO is force invoiced after cutoff"""


### PR DESCRIPTION
Replaces closed PR:
* https://github.com/OCA/account-closing/pull/352

Add better support for delivery lines. The delivery line should be invoiced when there is another line invoiceable. Add use case when a stock line has been delivered and returned before invoicing and cutoff. The delivery line, added at SO confirmation or at first delivery, should not be invoiceable yet. Once a new delivery occurs after cutoff, it should not affect that previous cutoff.

@lmignon